### PR TITLE
fix: realm search object in url bug

### DIFF
--- a/src/components/ui/search-result/search-result.tsx
+++ b/src/components/ui/search-result/search-result.tsx
@@ -135,7 +135,7 @@ const RealmsList = ({item, isMain, searchTitle, onClick}: SearchResultProps) => 
   const {getUrlWithNetwork} = useNetwork();
 
   return (
-    <Link href={getUrlWithNetwork(`/realms/details?path=${item}`)} passHref>
+    <Link href={getUrlWithNetwork(`/realms/details?path=${item.packagePath}`)} passHref>
       <FitContentA onClick={() => onClick(searchTitle, item)}>
         <Text type={isMain ? 'p4' : 'body1'} color="primary" className="ellipsis">
           {item.packagePath}


### PR DESCRIPTION
Currently, when clicking on a search result on the home page, the url becomes https://gnoscan.io/realms/details?path=[object%20Object] instead of, for example,  https://gnoscan.io/realms/details?path=gno.land/r/g1w62226g8hykfmtuasvz80rdf0jl6phgxsphh5v/testing/disperse

![image](https://github.com/user-attachments/assets/53370b14-5ee0-4d93-9808-3d7006e99c01)

<details>
<summary>Which results in an empty details page</summary>
<img src="https://github.com/user-attachments/assets/abb65071-7b03-4e62-9d4a-37266442fb3f"/>
</details>

This PR fixes this bug by updating the corresponding `href` to use `item.packagePath` instead of `item`, just like it is done elsewhere in the same file.