### PR TITLE
fix: format number to transaction info card

### DIFF
--- a/src/common/hooks/main/use-transaction-summary-info.ts
+++ b/src/common/hooks/main/use-transaction-summary-info.ts
@@ -52,7 +52,7 @@ export const useTransactionSummaryInfo = () => {
   const transactionTotalFee = useMemo(() => {
     return BigNumber(transactionTotalFeeAmount)
       .shiftedBy(GNOTToken.decimals * -1)
-      .toFixed(6);
+      .toFormat(6);
   }, [transactionTotalFeeAmount]);
 
   const transactionFeeAverage = useMemo(() => {
@@ -71,7 +71,7 @@ export const useTransactionSummaryInfo = () => {
     return BigNumber(feeAmount)
       .dividedBy(simpleTransactions?.length)
       .shiftedBy(GNOTToken.decimals * -1)
-      .toFixed(6);
+      .toFormat(6);
   }, [simpleTransactions]);
 
   return {


### PR DESCRIPTION
# Descriptions

On the Total Transactions card on the main screen, 
apply formatting to the gas fee average and the total gas fee. 

![image](https://github.com/user-attachments/assets/3510c463-36e1-4786-9a36-2210bec99c01)
