### PR TITLE
fix: fix transactions datatable

### DIFF
--- a/src/common/hooks/account/use-account.ts
+++ b/src/common/hooks/account/use-account.ts
@@ -1,11 +1,11 @@
-import {useMemo, useState} from 'react';
-import {GNOTToken, useTokenMeta} from '../common/use-token-meta';
 import {
   useGetAccountTransactions,
   useGetGRC20TokenBalances,
   useGetNativeTokenBalance,
 } from '@/common/react-query/account';
+import {useMemo, useState} from 'react';
 import {useMakeTransactionsWithTime} from '../common/use-make-transactions-with-time';
+import {GNOTToken, useTokenMeta} from '../common/use-token-meta';
 
 export const useAccount = (address: string) => {
   const {isFetchedGRC20Tokens, isFetchedTokenMeta} = useTokenMeta();
@@ -58,12 +58,12 @@ export const useAccount = (address: string) => {
   }, [accountTransactions]);
 
   const hasNextPage = useMemo(() => {
-    if (!accountTransactions) {
+    if (!transactions) {
       return false;
     }
 
-    return accountTransactions.length > (currentPage + 1) * 20;
-  }, [accountTransactions, currentPage]);
+    return transactions.length > (currentPage + 1) * 20;
+  }, [transactions, currentPage]);
 
   function nextPage() {
     setCurrentPage(prev => prev + 1);
@@ -78,7 +78,7 @@ export const useAccount = (address: string) => {
       isFetchedTokenMeta,
     accountTransactions: transactionWithTimes,
     transactionEvents,
-    isFetchedAccountTransactions: isFetchedTransactions && isFetchedTransactionWithTimes,
+    isFetchedAccountTransactions: isFetchedTransactions,
     tokenBalances,
     username: undefined,
     hasNextPage,

--- a/src/common/hooks/realms/use-realms.ts
+++ b/src/common/hooks/realms/use-realms.ts
@@ -21,6 +21,7 @@ export const useRealms = (
     data: defaultData,
     isFetched: isFetchedDefault,
     hasNextPage: hasNextPageDefault,
+    fetchNextPage,
   } = useGetRealmPackagesInfinity({enabled: !isCustomNetwork});
 
   const defaultFromHeight = useMemo(() => {
@@ -150,9 +151,10 @@ export const useRealms = (
 
   function nextPage() {
     if (!paging) {
+      setCurrentPage(prev => prev + 1);
       return;
     }
-    setCurrentPage(prev => prev + 1);
+    fetchNextPage();
   }
 
   useEffect(() => {

--- a/src/common/react-query/account/queries.ts
+++ b/src/common/react-query/account/queries.ts
@@ -1,17 +1,11 @@
-import {
-  InfiniteData,
-  UseInfiniteQueryOptions,
-  UseQueryOptions,
-  useInfiniteQuery,
-  useQuery,
-} from 'react-query';
-import {useServiceProvider} from '@/common/hooks/provider/use-service-provider';
-import {QUERY_KEY} from './types';
-import {Amount, Transaction} from '@/types/data-type';
-import {useNetworkProvider} from '@/common/hooks/provider/use-network-provider';
-import {parseTokenAmount} from '@/common/utils/token.utility';
 import {GNOTToken} from '@/common/hooks/common/use-token-meta';
+import {useNetworkProvider} from '@/common/hooks/provider/use-network-provider';
+import {useServiceProvider} from '@/common/hooks/provider/use-service-provider';
+import {parseTokenAmount} from '@/common/utils/token.utility';
 import {AccountTransactionResponse} from '@/repositories/account-repository';
+import {Amount, Transaction} from '@/types/data-type';
+import {UseQueryOptions, useQuery} from 'react-query';
+import {QUERY_KEY} from './types';
 
 export const useGetNativeTokenBalance = (
   address: string,

--- a/src/common/values/number.constant.ts
+++ b/src/common/values/number.constant.ts
@@ -1,0 +1,1 @@
+export const ZERO_NUMBER = 0 as const;

--- a/src/common/values/query.constant.ts
+++ b/src/common/values/query.constant.ts
@@ -1,0 +1,1 @@
+export const MAX_QUERY_SIZE = 10_000 as const;

--- a/src/repositories/account-repository/onbloc-account-repository.ts
+++ b/src/repositories/account-repository/onbloc-account-repository.ts
@@ -116,16 +116,20 @@ export class OnblocAccountRepository implements IAccountRepository {
         })
         .map(tx => {
           const defaultMessage = getDefaultMessage(tx.messages);
-          const typename = defaultMessage.__typename;
+          const typename: string | null = defaultMessage.__typename || null;
+          const functionName: string | null = defaultMessage?.func || null;
+          const messageArguments: string[] | null = defaultMessage?.args || null;
+
           switch (typename) {
             case 'BankMsgSend':
-              if (defaultMessage?.from_address === address) {
+              const fromAddress: string | null = defaultMessage?.from_address || null;
+              if (fromAddress === address) {
                 return mapSendTransactionByBankMsgSend(tx);
               }
               return mapReceivedTransactionByBankMsgSend(tx);
             case 'MsgCall':
-              if (defaultMessage?.func === 'Transfer') {
-                if (defaultMessage.args?.[0] === address) {
+              if (functionName === 'Transfer') {
+                if (messageArguments && messageArguments[ZERO_NUMBER] === address) {
                   return mapReceivedTransactionByMsgCall(tx);
                 }
               }

--- a/src/repositories/account-repository/onbloc-query.ts
+++ b/src/repositories/account-repository/onbloc-query.ts
@@ -8,7 +8,6 @@ export const makeAccountTransactionsQuery = (
   {
     transactions(
       filter: {
-        success: true
         messages: [
           {
             type_url: send


### PR DESCRIPTION
## Descriptions

- Change the detail page to show more than 20 transactions.
- Change the functionality of the View More button on the Realm page to work properly.
- When you view the list of account transactions, it also shows failed transactions.