### PR TITLE
feat: add transaction error log

### DIFF
--- a/src/common/hooks/transactions/use-transaction.ts
+++ b/src/common/hooks/transactions/use-transaction.ts
@@ -1,15 +1,16 @@
-import {useGetTransactionBlockHeightQuery} from '@/common/react-query/transaction';
+import BigNumber from 'bignumber.js';
 import {useMemo} from 'react';
+
+import {useGetTransactionBlockHeightQuery} from '@/common/react-query/transaction';
 import {getDateDiff, getLocalDateString} from '@/common/utils/date-util';
+import {makeDisplayNumber} from '@/common/utils/string-util';
+import {parseTokenAmount} from '@/common/utils/token.utility';
 import {
   decodeTransaction,
   makeSafeBase64Hash,
   makeTransactionMessageInfo,
 } from '@/common/utils/transaction.utility';
 import {Transaction} from '@/types/data-type';
-import {makeDisplayNumber} from '@/common/utils/string-util';
-import BigNumber from 'bignumber.js';
-import {parseTokenAmount} from '@/common/utils/token.utility';
 import {GNOTToken, useTokenMeta} from '../common/use-token-meta';
 
 export const useTransaction = (hash: string) => {
@@ -163,6 +164,7 @@ export const useTransaction = (hash: string) => {
   return {
     network,
     timeStamp,
+    blockResult,
     gas,
     transactionItem,
     transactionEvents,

--- a/src/components/ui/show-log/show-log.tsx
+++ b/src/components/ui/show-log/show-log.tsx
@@ -1,11 +1,11 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
-import styled, {css} from 'styled-components';
 import {isDesktop} from '@/common/hooks/use-media';
-import Text from '@/components/ui/text';
-import {ViewMoreButton} from '@/components/ui/button';
-import mixins from '@/styles/mixins';
-import {v1} from 'uuid';
 import {scrollbarStyle, useScrollbar} from '@/common/hooks/use-scroll-bar';
+import {ViewMoreButton} from '@/components/ui/button';
+import Text from '@/components/ui/text';
+import mixins from '@/styles/mixins';
+import React, {useCallback, useRef, useState} from 'react';
+import styled, {css} from 'styled-components';
+import {v1} from 'uuid';
 interface StyleProps {
   desktop?: boolean;
   showLog?: boolean;
@@ -131,10 +131,7 @@ const ShowLog = ({isTabLog, logData = '', files, btnTextType = ''}: ShowLogProps
             </div>
           </TabLogWrap>
         ) : (
-          <LogWrap
-            desktop={desktop}
-            showLog={showLog}
-            className={scrollVisible ? 'scroll-visible' : ''}>
+          <LogWrap desktop={desktop} showLog={showLog} className={'scroll-visible'}>
             <Log
               onMouseEnter={onFocusIn}
               onMouseLeave={onFocusOut}

--- a/src/pages/transactions/details.tsx
+++ b/src/pages/transactions/details.tsx
@@ -52,8 +52,16 @@ const TransactionDetails = () => {
   const {asPath, push} = useRouter();
   const {getUrlWithNetwork} = useNetwork();
   const hash = parseTxHash(asPath);
-  const {gas, network, timeStamp, transactionItem, transactionEvents, isFetched, isError} =
-    useTransaction(hash);
+  const {
+    gas,
+    network,
+    timeStamp,
+    transactionItem,
+    blockResult,
+    transactionEvents,
+    isFetched,
+    isError,
+  } = useTransaction(hash);
   const [currentTab, setCurrentTab] = useState('Contract');
 
   const detailTabs = useMemo(() => {
@@ -67,6 +75,18 @@ const TransactionDetails = () => {
       },
     ];
   }, [transactionEvents]);
+
+  const blockResultLog = useMemo(() => {
+    if (transactionItem?.success !== false) {
+      return null;
+    }
+
+    try {
+      return JSON.stringify(blockResult, null, 2);
+    } catch {
+      return null;
+    }
+  }, [transactionItem, blockResult]);
 
   useEffect(() => {
     if (hash === '') {
@@ -162,6 +182,9 @@ const TransactionDetails = () => {
                 <Badge>{transactionItem.memo}</Badge>
               </dd>
             </DLWrap>
+            {!transactionItem.success && (
+              <ShowLog isTabLog={false} logData={blockResultLog || ''} btnTextType="Error Logs" />
+            )}
           </DataSection>
 
           <DataListSection tabs={detailTabs} currentTab={currentTab} setCurrentTab={setCurrentTab}>


### PR DESCRIPTION
## Descriptions

The Failed transactions page shows the block response results.
<img width="1033" alt="image" src="https://github.com/user-attachments/assets/9419d584-cbd2-4fc3-a554-cf119d02e18f">
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/be8b77b0-62cb-4032-9dbe-af0802ba71ba">
