### PR TITLE
chore: fix max query size to indexer

### DIFF
--- a/src/common/values/query.constant.ts
+++ b/src/common/values/query.constant.ts
@@ -1,1 +1,4 @@
-export const MAX_QUERY_SIZE = 10_000 as const;
+/**
+ * Set the maximum query size to a number that is one less than the indexer's maximum query size of 10,000.
+ */
+export const MAX_QUERY_SIZE = 9_999 as const;


### PR DESCRIPTION
## Descriptions

Set the maximum query size to a number that is one less than the indexer's maximum query size of 10,000.