### PR TITLE
[GNS-255] Implement UI layer seperation for blocks page

### DIFF
--- a/src/common/hooks/blocks/use-blocks.ts
+++ b/src/common/hooks/blocks/use-blocks.ts
@@ -6,7 +6,7 @@ export const useBlocks = () => {
   const { data: latestBlockHeight } = useGetLatestBlockHeightQuery();
   const [currentBlockHeight, setCurrentBlockHeight] = useState<number>();
 
-  const { data, fetchNextPage, hasNextPage, isFetched, isError } = useGetBlocksQuery(currentBlockHeight);
+  const { data, fetchNextPage, hasNextPage, isFetched, isError, isLoading } = useGetBlocksQuery(currentBlockHeight);
 
   const blocks = useMemo(() => {
     if (!data?.pages) {
@@ -27,6 +27,7 @@ export const useBlocks = () => {
   return {
     data: blocks,
     isFetched: isFetched && latestBlockHeight !== undefined,
+    isLoading,
     isError: latestBlockHeight === null || isError,
     fetchNextPage,
     hasNextPage,

--- a/src/components/view/account/account-address/AccountAddress.styles.ts
+++ b/src/components/view/account/account-address/AccountAddress.styles.ts
@@ -1,7 +1,8 @@
 import styled, { css } from "styled-components";
 
 import mixins from "@/styles/mixins";
-import { DEVICE_TYPE, media } from "@/common/values/ui.constant";
+import { DEVICE_TYPE } from "@/common/values/ui.constant";
+import { SkeletonBoxStyle } from "@/components/ui/loading";
 
 import Text from "@/components/ui/text";
 import Tooltip from "@/components/ui/tooltip";
@@ -88,4 +89,17 @@ export const Username = styled(Text)<{ breakpoint: DEVICE_TYPE }>`
     ${mixins.posTopCenterLeft(0)};
     margin-left: ${({ breakpoint }) => (breakpoint === DEVICE_TYPE.MOBILE ? "7px" : "20px")};
   }
+`;
+
+export const SkeletonBox = styled(SkeletonBoxStyle)<{
+  width?: string;
+  marginTop?: number;
+  marginBottom?: number;
+  height?: number;
+}>`
+  ${mixins.flexbox("column", "flex-start", "flex-start")};
+  width: ${({ width }) => width ?? "100%"};
+  margin-top: ${({ marginTop }) => (marginTop ? `${marginTop}px` : "0")};
+  margin-bottom: ${({ marginBottom }) => (marginBottom ? `${marginBottom}px` : "0")};
+  height: ${({ height }) => (height ? `${height}px` : "28px")};
 `;

--- a/src/components/view/account/account-address/AccountAddressSkeleton.tsx
+++ b/src/components/view/account/account-address/AccountAddressSkeleton.tsx
@@ -1,22 +1,6 @@
 import React from "react";
-import styled from "styled-components";
 
 import * as S from "./AccountAddress.styles";
-import { SkeletonBoxStyle } from "@/components/ui/loading";
-import mixins from "@/styles/mixins";
-
-const SkeletonBox = styled(SkeletonBoxStyle)<{
-  width?: string;
-  marginTop?: number;
-  marginBottom?: number;
-  height?: number;
-}>`
-  ${mixins.flexbox("column", "flex-start", "flex-start")};
-  width: ${({ width }) => width ?? "100%"};
-  margin-top: ${({ marginTop }) => (marginTop ? `${marginTop}px` : "0")};
-  margin-bottom: ${({ marginBottom }) => (marginBottom ? `${marginBottom}px` : "0")};
-  height: ${({ height }) => (height ? `${height}px` : "28px")};
-`;
 
 interface AccountAddressSkeletonProps {
   isDesktop: boolean;
@@ -25,9 +9,9 @@ interface AccountAddressSkeletonProps {
 const AccountAddressSkeleton = ({ isDesktop }: AccountAddressSkeletonProps) => {
   return (
     <S.Card isDesktop={isDesktop}>
-      <SkeletonBox width={"30%"} height={14} marginBottom={10} />
-      <SkeletonBox width={"20%"} height={14} />
-      <SkeletonBox width={"50%"} height={14} />
+      <S.SkeletonBox width={"30%"} height={14} marginBottom={10} />
+      <S.SkeletonBox width={"20%"} height={14} />
+      <S.SkeletonBox width={"50%"} height={14} />
     </S.Card>
   );
 };

--- a/src/components/view/common/page-title/PageTitle.tsx
+++ b/src/components/view/common/page-title/PageTitle.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 import styled from "styled-components";
 
+import { FontsType } from "@/styles";
+
 import Text from "@/components/ui/text";
 
 interface PageTitleProps {
   title: string;
+  type: FontsType;
 }
 
-export const PageTitle = ({ title }: PageTitleProps) => {
+export const PageTitle = ({ title, type }: PageTitleProps) => {
   return (
-    <Title type={"h2"} color="primary">
+    <Title type={type} color="primary">
       {title}
     </Title>
   );

--- a/src/components/view/common/page-title/PageTitle.tsx
+++ b/src/components/view/common/page-title/PageTitle.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import styled from "styled-components";
+
+import Text from "@/components/ui/text";
+
+interface PageTitleProps {
+  title: string;
+}
+
+export const PageTitle = ({ title }: PageTitleProps) => {
+  return (
+    <Title type={"h2"} color="primary">
+      {title}
+    </Title>
+  );
+};
+
+const Title = styled(Text)``;

--- a/src/components/view/common/table-skeleton/TableSkeleton.styles.ts
+++ b/src/components/view/common/table-skeleton/TableSkeleton.styles.ts
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+
+import mixins from "@/styles/mixins";
+import { SkeletonBoxStyle } from "@/components/ui/loading";
+
+export const Card = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+
+  background-color: ${({ theme }) => theme.colors.base};
+  border-radius: 10px;
+  width: 100%;
+  padding: 24px;
+`;
+
+export const SkeletonBox = styled(SkeletonBoxStyle)<{
+  width?: string;
+  marginTop?: number;
+  marginBottom?: number;
+  height?: number;
+}>`
+  ${mixins.flexbox("column", "flex-start", "flex-start")};
+  width: ${({ width }) => width ?? "100%"};
+  margin-top: ${({ marginTop }) => (marginTop ? `${marginTop}px` : "0")};
+  margin-bottom: ${({ marginBottom }) => (marginBottom ? `${marginBottom}px` : "0")};
+  height: ${({ height }) => (height ? `${height}px` : "28px")};
+`;

--- a/src/components/view/common/table-skeleton/TableSkeleton.tsx
+++ b/src/components/view/common/table-skeleton/TableSkeleton.tsx
@@ -1,0 +1,16 @@
+import * as S from "./TableSkeleton.styles";
+
+const TableSkeleton = () => {
+  return (
+    <S.Card>
+      <S.SkeletonBox width="30%" height={16} marginBottom={20} />
+      <S.SkeletonBox width="100%" height={18} />
+      <S.SkeletonBox width="100%" height={18} />
+      <S.SkeletonBox width="100%" height={18} />
+      <S.SkeletonBox width="100%" height={18} />
+      <S.SkeletonBox width="30%" height={16} />
+    </S.Card>
+  );
+};
+
+export default TableSkeleton;

--- a/src/components/view/datatable/block/block.tsx
+++ b/src/components/view/datatable/block/block.tsx
@@ -1,27 +1,34 @@
 "use client";
 
 import React from "react";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+
+import { numberWithCommas } from "@/common/utils";
+import { themeState } from "@/states";
+import { useUsername } from "@/common/hooks/account/use-username";
+import { DEVICE_TYPE } from "@/common/values/ui.constant";
+import theme from "@/styles/theme";
+
 import Datatable, { DatatableOption } from "@/components/ui/datatable";
 import { DatatableItem } from "..";
-import { numberWithCommas } from "@/common/utils";
-import useLoading from "@/common/hooks/use-loading";
-import { useRecoilValue } from "recoil";
-import { themeState } from "@/states";
 import { Block } from "@/types/data-type";
 import { Button } from "@/components/ui/button";
-import { eachMedia } from "@/common/hooks/use-media";
-import styled from "styled-components";
-import theme from "@/styles/theme";
-import { useBlocks } from "@/common/hooks/blocks/use-blocks";
-import { useUsername } from "@/common/hooks/account/use-username";
 
-export const BlockDatatable = () => {
-  const media = eachMedia();
+interface BlockDatatableProps {
+  breakpoint: DEVICE_TYPE;
+  data: Block[];
+  isFetched: boolean;
+  isError: boolean;
+  isLoading: boolean;
+  hasNextPage: boolean | undefined;
+
+  fetchNextPage: () => void;
+}
+
+export const BlockDatatable = ({ breakpoint, data, isError, hasNextPage, fetchNextPage }: BlockDatatableProps) => {
   const themeMode = useRecoilValue(themeState);
-  const { data: blocks, isFetched, fetchNextPage, hasNextPage, isError } = useBlocks();
   const { getNameWithMoniker } = useUsername();
-
-  useLoading({ finished: isFetched || isError });
 
   const createHeaders = () => {
     return [
@@ -108,12 +115,12 @@ export const BlockDatatable = () => {
             themeMode: themeMode,
           };
         })}
-        datas={blocks}
+        datas={data}
       />
 
       {hasNextPage ? (
         <div className="button-wrapper">
-          <Button className={`more-button ${media}`} radius={"4px"} onClick={() => fetchNextPage()}>
+          <Button className={`more-button ${breakpoint}`} radius={"4px"} onClick={() => fetchNextPage()}>
             {"View More Blocks"}
           </Button>
         </div>

--- a/src/components/view/datatable/item/block-hash.tsx
+++ b/src/components/view/datatable/item/block-hash.tsx
@@ -9,5 +9,5 @@ interface Props {
 
 export const BlockHash = ({ hash, height }: Props) => {
   const { getUrlWithNetwork } = useNetwork();
-  return height ? <a href={getUrlWithNetwork(`/blocks/${height}`)}>{textEllipsis(hash ?? "", 8)}</a> : <span>-</span>;
+  return height ? <a href={getUrlWithNetwork(`/block/${height}`)}>{textEllipsis(hash ?? "", 8)}</a> : <span>-</span>;
 };

--- a/src/components/view/datatable/item/block.tsx
+++ b/src/components/view/datatable/item/block.tsx
@@ -8,5 +8,5 @@ interface Props {
 
 export const Block = ({ height }: Props) => {
   const { getUrlWithNetwork } = useNetwork();
-  return height ? <a href={getUrlWithNetwork(`/blocks/${height}`)}>{height}</a> : <span>-</span>;
+  return height ? <a href={getUrlWithNetwork(`/block/${height}`)}>{height}</a> : <span>-</span>;
 };

--- a/src/components/view/main-active-list/active-newest/active-newest.tsx
+++ b/src/components/view/main-active-list/active-newest/active-newest.tsx
@@ -68,7 +68,7 @@ const ActiveNewest = () => {
               <LazyRealmCalls path={realm.packagePath} />
               <StyledText type="p4" width={colWidth.newest[5]} color="blue">
                 <FitContentA>
-                  <Link href={getUrlWithNetwork(`/blocks/${realm.blockHeight}`)} passHref>
+                  <Link href={getUrlWithNetwork(`/block/${realm.blockHeight}`)} passHref>
                     {realm.blockHeight}
                   </Link>
                 </FitContentA>

--- a/src/containers/blocks/block-list-container/BlockListContainer.tsx
+++ b/src/containers/blocks/block-list-container/BlockListContainer.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { useBlocks } from "@/common/hooks/blocks/use-blocks";
+import { useWindowSize } from "@/common/hooks/use-window-size";
+
+import { BlockDatatable } from "@/components/view/datatable";
+import TableSkeleton from "@/components/view/common/table-skeleton/TableSkeleton";
+
+const BlockListContainer = () => {
+  const { breakpoint } = useWindowSize();
+  const { data: blocks, isFetched, fetchNextPage, hasNextPage, isError, isLoading } = useBlocks();
+
+  if (isLoading || !isFetched) return <TableSkeleton />;
+
+  return (
+    <BlockDatatable
+      breakpoint={breakpoint}
+      data={blocks}
+      isFetched={isFetched}
+      isError={isError}
+      isLoading={isLoading}
+      hasNextPage={hasNextPage}
+      fetchNextPage={fetchNextPage}
+    />
+  );
+};
+
+export default BlockListContainer;

--- a/src/layouts/account/AccountLayout.tsx
+++ b/src/layouts/account/AccountLayout.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useWindowSize } from "@/common/hooks/use-window-size";
 
 import * as S from "./AccountLayout.styles";
-import Text from "@/components/ui/text";
+import { PageTitle } from "@/components/view/common/page-title/PageTitle";
 
 interface AccountLayoutProps {
   accountAddress: React.ReactNode;
@@ -18,9 +18,7 @@ const AccountLayout = ({ accountAddress, accountAssets, accountTransactions }: A
     <S.Container breakpoint={breakpoint}>
       <S.InnerLayout>
         <S.Wrapper breakpoint={breakpoint}>
-          <Text type={isDesktop ? "h2" : "p2"} color="primary">
-            Account Details
-          </Text>
+          <PageTitle type={isDesktop ? "h2" : "p2"} title="Account Details" />
           {accountAddress}
           {accountAssets}
           {accountTransactions}

--- a/src/layouts/blocks/BlocksLayout.styles.ts
+++ b/src/layouts/blocks/BlocksLayout.styles.ts
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+
+import { DEVICE_TYPE } from "@/common/values/ui.constant";
+import { innerLayoutCss } from "@/styles/css/inner-layout";
+
+export const Container = styled.main`
+  width: 100%;
+  flex: 1;
+  padding: 40px 0;
+`;
+
+export const InnerLayout = styled.div`
+  ${innerLayoutCss}
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  width: 100%;
+  padding: 24px;
+  border-radius: 10px;
+
+  background-color: ${({ theme }) => theme.colors.surface};
+`;

--- a/src/layouts/blocks/BlocksLayout.tsx
+++ b/src/layouts/blocks/BlocksLayout.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import * as S from "./BlocksLayout.styles";
+import Text from "@/components/ui/text";
+
+interface BlocksLayoutProps {
+  blockList: React.ReactNode;
+}
+
+const BlocksLayout = ({ blockList }: BlocksLayoutProps) => {
+  return (
+    <S.Container>
+      <S.InnerLayout>
+        <S.Wrapper>
+          <Text type="h2" color="primary">
+            {"Blocks"}
+          </Text>
+          {blockList}
+        </S.Wrapper>
+      </S.InnerLayout>
+    </S.Container>
+  );
+};
+
+export default BlocksLayout;

--- a/src/layouts/blocks/BlocksLayout.tsx
+++ b/src/layouts/blocks/BlocksLayout.tsx
@@ -12,7 +12,7 @@ const BlocksLayout = ({ blockList }: BlocksLayoutProps) => {
     <S.Container>
       <S.InnerLayout>
         <S.Wrapper>
-          <PageTitle title="Blocks" />
+          <PageTitle title="Blocks" type="h2" />
           {blockList}
         </S.Wrapper>
       </S.InnerLayout>

--- a/src/layouts/blocks/BlocksLayout.tsx
+++ b/src/layouts/blocks/BlocksLayout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import * as S from "./BlocksLayout.styles";
-import Text from "@/components/ui/text";
+import { PageTitle } from "@/components/view/common/page-title/PageTitle";
 
 interface BlocksLayoutProps {
   blockList: React.ReactNode;
@@ -12,9 +12,7 @@ const BlocksLayout = ({ blockList }: BlocksLayoutProps) => {
     <S.Container>
       <S.InnerLayout>
         <S.Wrapper>
-          <Text type="h2" color="primary">
-            {"Blocks"}
-          </Text>
+          <PageTitle title="Blocks" />
           {blockList}
         </S.Wrapper>
       </S.InnerLayout>

--- a/src/pages/block/[height].tsx
+++ b/src/pages/block/[height].tsx
@@ -89,11 +89,11 @@ const BlockDetails = () => {
           <TitleOption
             prevProps={{
               disabled: !block?.hasPreviousBlock,
-              path: `/blocks/${Number(block.blockHeight) - 1}`,
+              path: `/block/${Number(block.blockHeight) - 1}`,
             }}
             nextProps={{
               disabled: !block?.hasNextBlock,
-              path: `/blocks/${Number(block.blockHeight) + 1}`,
+              path: `/block/${Number(block.blockHeight) + 1}`,
             }}
           />
         )

--- a/src/pages/blocks/index.tsx
+++ b/src/pages/blocks/index.tsx
@@ -1,42 +1,8 @@
-import useLoading from "@/common/hooks/use-loading";
-import Text from "@/components/ui/text";
-import { BlockDatatable } from "@/components/view/datatable";
-import LoadingPage from "@/components/view/loading/page";
 import React from "react";
-import styled from "styled-components";
 
-const Block = () => {
-  const { loading } = useLoading();
+import BlocksLayout from "@/layouts/blocks/BlocksLayout";
+const BlockListContainer = React.lazy(() => import("@/containers/blocks/block-list-container/BlockListContainer"));
 
-  return (
-    <Container>
-      <div className="inner-layout">
-        <LoadingPage visible={loading} />
-        <Wrapper visible={!loading}>
-          <Text type="h2" margin={"0 0 24px 0"} color="primary">
-            {"Blocks"}
-          </Text>
-          <BlockDatatable />
-        </Wrapper>
-      </div>
-    </Container>
-  );
-};
-
-const Container = styled.main`
-  width: 100%;
-  flex: 1;
-`;
-
-const Wrapper = styled.div<{ visible?: boolean }>`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  margin: 40px 0;
-  padding: 24px;
-  background-color: ${({ theme }) => theme.colors.surface};
-  border-radius: 10px;
-  ${({ visible }) => !visible && "display: none;"}
-`;
-
-export default Block;
+export default function Page() {
+  return <BlocksLayout blockList={<BlockListContainer />} />;
+}

--- a/src/pages/realms/details.tsx
+++ b/src/pages/realms/details.tsx
@@ -221,7 +221,7 @@ const RealmsDetails = ({ path }: RealmsDetailsPageProps) => {
                       </Text>
                     </FitContentA>
                   ) : (
-                    <Link href={getUrlWithNetwork(`/blocks/${summary?.blockPublished}`)} passHref>
+                    <Link href={getUrlWithNetwork(`/block/${summary?.blockPublished}`)} passHref>
                       <FitContentA>
                         <Text type="p4" color="blue">
                           {summary?.blockPublished}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -78,7 +78,7 @@ export async function getServerSideProps({ req }: any) {
         redirect: {
           keyword,
           permanent: false,
-          destination: `/blocks/${keyword}?${queryString}`,
+          destination: `/block/${keyword}?${queryString}`,
         },
       };
     }

--- a/src/pages/transactions/details.tsx
+++ b/src/pages/transactions/details.tsx
@@ -136,7 +136,7 @@ const TransactionDetails = () => {
               <dt>Block</dt>
               <dd>
                 <Badge>
-                  <Link href={getUrlWithNetwork(`/blocks/${transactionItem.blockHeight}`)} passHref>
+                  <Link href={getUrlWithNetwork(`/block/${transactionItem.blockHeight}`)} passHref>
                     <FitContentA>
                       <Text type="p4" color="blue">
                         {transactionItem.blockHeight}


### PR DESCRIPTION
## Description
This PR introduces UI layer separation for the Blocks page as the first step in our application architecture restructuring. This is part of a larger initiative to establish clear boundaries between different UI concerns across all pages.

## Details
![Gnoscan_Architecture](https://github.com/user-attachments/assets/27326760-ffc2-4b64-9e3f-f6f1d283f3f8)


### Layer Separation
- **Pages**: Simplified Blocks page to serve primarily as a routing entry point
- **Containers**: Added to handle data fetching and business logic
- **Layouts**: Created dedicated layout components for structural organization
- **Components**: Refactored to focus on presentation and reusability
- **Atomic**: Extracted and organized consistently across components
### Data Flow Improvements
The new architecture creates a clear, predictable data flow:
- Data is fetched and processed in container components
- Processed data flows down to layout and presentation components via props
- User interactions trigger callbacks that flow back up the component hierarchy
- State is managed at appropriate levels to minimize unnecessary re-renders
### Implementation Plan
- This PR focuses on the Blocks page only
- Additional pages will be refactored in subsequent PRs to make code reviews more manageable
