### PR TITLE
[GNS-255] Implement UI layer seperation for realms page

### DIFF
--- a/src/components/view/datatable/index.ts
+++ b/src/components/view/datatable/index.ts
@@ -1,6 +1,5 @@
 export * as DatatableItem from "./item";
 export * from "./block";
-export * from "./realm";
 export * from "./account-detail";
 export * from "./block-detail";
 export * from "./realm-detail";

--- a/src/components/view/datatable/realm/index.ts
+++ b/src/components/view/datatable/realm/index.ts
@@ -1,1 +1,0 @@
-export * from "./realm";

--- a/src/components/view/realms/realm-list-table/RealmListTable.styles.ts
+++ b/src/components/view/realms/realm-list-table/RealmListTable.styles.ts
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+export const Container = styled.div<{ maxWidth?: number }>`
+  & {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: auto;
+    align-items: center;
+    background-color: ${({ theme }) => theme.colors.base};
+    padding-bottom: 24px;
+    border-radius: 10px;
+
+    .button-wrapper {
+      display: flex;
+      width: 100%;
+      height: auto;
+      margin-top: 4px;
+      padding: 0 20px;
+      justify-content: center;
+
+      .more-button {
+        width: 100%;
+        padding: 16px;
+        color: ${({ theme }) => theme.colors.primary};
+        background-color: ${({ theme }) => theme.colors.surface};
+        ${({ theme }) => theme.fonts.p4}
+        font-weight: 600;
+
+        &.desktop {
+          width: 344px;
+        }
+      }
+    }
+  }
+`;

--- a/src/components/view/realms/realm-list-table/RealmListTable.tsx
+++ b/src/components/view/realms/realm-list-table/RealmListTable.tsx
@@ -1,19 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 "use client";
-
-import React, { useState } from "react";
-import Datatable, { DatatableOption } from "@/components/ui/datatable";
-import { DatatableItem } from "..";
-import { Button } from "@/components/ui/button";
-import styled from "styled-components";
-import theme from "@/styles/theme";
-import { eachMedia } from "@/common/hooks/use-media";
-import useLoading from "@/common/hooks/use-loading";
+import React from "react";
 import { useRecoilValue } from "recoil";
-import { themeState } from "@/states";
-import { useRealms } from "@/common/hooks/realms/use-realms";
-import { useUsername } from "@/common/hooks/account/use-username";
+
 import { useNetworkProvider } from "@/common/hooks/provider/use-network-provider";
+import { DEVICE_TYPE } from "@/common/values/ui.constant";
+import { themeState } from "@/states";
+
+import * as S from "./RealmListTable.styles";
+import Datatable, { DatatableOption } from "@/components/ui/datatable";
+import { DatatableItem } from "../../datatable";
+import { Button } from "@/components/ui/button";
+import TableSkeleton from "../../common/table-skeleton/TableSkeleton";
 
 const TOOLTIP_PATH = (
   <>
@@ -22,24 +20,33 @@ const TOOLTIP_PATH = (
   </>
 );
 
-export const RealmDatatable = () => {
-  const media = eachMedia();
+interface RealmListTableProps {
+  breakpoint: DEVICE_TYPE;
+  sortOption: { field: string; order: string };
+  realms: any;
+  isFetched: boolean;
+  hasNextPage?: boolean;
+  isDefault: boolean;
+  defaultFromHeight: number | null;
+  fetchNextPage: () => void;
+  setSortOption: (sortOption: { field: string; order: string }) => void;
+  getName: (address: string) => string;
+}
+
+export const RealmListTable = ({
+  breakpoint,
+  sortOption,
+  setSortOption,
+  realms,
+  isFetched,
+  hasNextPage,
+  fetchNextPage,
+  isDefault,
+  defaultFromHeight,
+  getName,
+}: RealmListTableProps) => {
   const themeMode = useRecoilValue(themeState);
   const { indexerQueryClient } = useNetworkProvider();
-  const [sortOption, setSortOption] = useState<{ field: string; order: string }>({
-    field: "none",
-    order: "none",
-  });
-  const {
-    realms,
-    isFetched,
-    hasNextPage,
-    nextPage: fetchNextPage,
-    isDefault,
-    defaultFromHeight,
-  } = useRealms(true, sortOption);
-  const { isFetched: isFetchedUsername, getName } = useUsername();
-  useLoading({ finished: isFetched && isFetchedUsername });
 
   const createHeaders = () => {
     return [
@@ -128,8 +135,10 @@ export const RealmDatatable = () => {
       .build();
   };
 
+  if (!isFetched) return <TableSkeleton />;
+
   return (
-    <Container>
+    <S.Container>
       <Datatable
         headers={createHeaders().map(item => {
           return {
@@ -145,48 +154,13 @@ export const RealmDatatable = () => {
 
       {hasNextPage ? (
         <div className="button-wrapper">
-          <Button className={`more-button ${media}`} radius={"4px"} onClick={() => fetchNextPage()}>
+          <Button className={`more-button ${breakpoint}`} radius={"4px"} onClick={() => fetchNextPage()}>
             {"View More Realms"}
           </Button>
         </div>
       ) : (
         <></>
       )}
-    </Container>
+    </S.Container>
   );
 };
-
-const Container = styled.div<{ maxWidth?: number }>`
-  & {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    height: auto;
-    align-items: center;
-    background-color: ${({ theme }) => theme.colors.base};
-    padding-bottom: 24px;
-    border-radius: 10px;
-
-    .button-wrapper {
-      display: flex;
-      width: 100%;
-      height: auto;
-      margin-top: 4px;
-      padding: 0 20px;
-      justify-content: center;
-
-      .more-button {
-        width: 100%;
-        padding: 16px;
-        color: ${({ theme }) => theme.colors.primary};
-        background-color: ${({ theme }) => theme.colors.surface};
-        ${theme.fonts.p4}
-        font-weight: 600;
-
-        &.desktop {
-          width: 344px;
-        }
-      }
-    }
-  }
-`;

--- a/src/containers/realms/realm-list-container/RealmListContainer.tsx
+++ b/src/containers/realms/realm-list-container/RealmListContainer.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { useWindowSize } from "@/common/hooks/use-window-size";
+import { useRealms } from "@/common/hooks/realms/use-realms";
+import { useUsername } from "@/common/hooks/account/use-username";
+
+import { RealmListTable } from "@/components/view/realms/realm-list-table/RealmListTable";
+
+const RealmListContainer = () => {
+  const { breakpoint } = useWindowSize();
+
+  const [sortOption, setSortOption] = React.useState<{ field: string; order: string }>({
+    field: "none",
+    order: "none",
+  });
+
+  const { isFetched: isFetchedUsername, getName } = useUsername();
+  const {
+    realms,
+    isFetched: isFetchedRealms,
+    hasNextPage,
+    nextPage: fetchNextPage,
+    isDefault,
+    defaultFromHeight,
+  } = useRealms(true, sortOption);
+
+  return (
+    <RealmListTable
+      breakpoint={breakpoint}
+      sortOption={sortOption}
+      setSortOption={setSortOption}
+      realms={realms}
+      isFetched={isFetchedUsername && isFetchedRealms}
+      hasNextPage={hasNextPage}
+      fetchNextPage={fetchNextPage}
+      isDefault={isDefault}
+      defaultFromHeight={defaultFromHeight}
+      getName={getName}
+    />
+  );
+};
+
+export default RealmListContainer;

--- a/src/layouts/realms/RealmsLayout.styles.ts
+++ b/src/layouts/realms/RealmsLayout.styles.ts
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+import { innerLayoutCss } from "@/styles/css/inner-layout";
+
+export const Container = styled.main`
+  width: 100%;
+  flex: 1;
+  padding: 40px 0;
+`;
+
+export const InnerLayout = styled.div`
+  ${innerLayoutCss}
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  width: 100%;
+  padding: 24px;
+  border-radius: 10px;
+
+  background-color: ${({ theme }) => theme.colors.surface};
+`;

--- a/src/layouts/realms/RealmsLayout.tsx
+++ b/src/layouts/realms/RealmsLayout.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import * as S from "./RealmsLayout.styles";
+import { PageTitle } from "@/components/view/common/page-title/PageTitle";
+
+interface RealmsLayoutProps {
+  realmList: React.ReactNode;
+}
+
+const RealmsLayout = ({ realmList }: RealmsLayoutProps) => {
+  return (
+    <S.Container>
+      <S.InnerLayout>
+        <S.Wrapper>
+          <PageTitle title="Realms" type="h2" />
+          {realmList}
+        </S.Wrapper>
+      </S.InnerLayout>
+    </S.Container>
+  );
+};
+
+export default RealmsLayout;

--- a/src/pages/realms/index.tsx
+++ b/src/pages/realms/index.tsx
@@ -1,42 +1,12 @@
-import useLoading from "@/common/hooks/use-loading";
-import Text from "@/components/ui/text";
-import { RealmDatatable } from "@/components/view/datatable/realm";
-import LoadingPage from "@/components/view/loading/page";
 import React from "react";
-import styled from "styled-components";
 
-const Realms = () => {
-  const { loading } = useLoading();
+import RealmsLayout from "@/layouts/realms/RealmsLayout";
+const RealmListContainer = React.lazy(() => import("@/containers/realms/realm-list-container/RealmListContainer"));
 
+export default function Page() {
   return (
-    <Container>
-      <div className="inner-layout">
-        <LoadingPage visible={loading} />
-        <Wrapper visible={!loading}>
-          <Text type="h2" margin={"0 0 24px 0"} color="primary">
-            {"Realms"}
-          </Text>
-          <RealmDatatable />
-        </Wrapper>
-      </div>
-    </Container>
+    <>
+      <RealmsLayout realmList={<RealmListContainer />} />
+    </>
   );
-};
-
-const Container = styled.main`
-  width: 100%;
-  flex: 1;
-`;
-
-const Wrapper = styled.div<{ visible?: boolean }>`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  margin: 40px 0;
-  padding: 24px;
-  background-color: ${({ theme }) => theme.colors.surface};
-  border-radius: 10px;
-  ${({ visible }) => !visible && "display: none;"}
-`;
-
-export default Realms;
+}


### PR DESCRIPTION
## Description
This PR introduces UI layer separation for the Realms page as the first step in our application architecture restructuring. This is part of a larger initiative to establish clear boundaries between different UI concerns across all pages.

## Details
![Gnoscan_Architecture](https://github.com/user-attachments/assets/27326760-ffc2-4b64-9e3f-f6f1d283f3f8)


### Layer Separation
- **Pages**: Simplified Realms page to serve primarily as a routing entry point
- **Containers**: Added to handle data fetching and business logic
- **Layouts**: Created dedicated layout components for structural organization
- **Components**: Refactored to focus on presentation and reusability
- **Atomic**: Extracted and organized consistently across components
### Data Flow Improvements
The new architecture creates a clear, predictable data flow:
- Data is fetched and processed in container components
- Processed data flows down to layout and presentation components via props
- User interactions trigger callbacks that flow back up the component hierarchy
- State is managed at appropriate levels to minimize unnecessary re-renders
### Implementation Plan
- This PR focuses on the Realms page only
- Additional pages will be refactored in subsequent PRs to make code reviews more manageable
