### PR TITLE
[GNS-258] ShowLog Temporary data (rawContent)

### DIFF
--- a/src/components/view/transaction/transaction-contract-details/StandardNetworkTransactionContractsDetails.tsx
+++ b/src/components/view/transaction/transaction-contract-details/StandardNetworkTransactionContractsDetails.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import Link from "next/link";
 
-import { Amount, Transaction, TransactionContractInfo } from "@/types/data-type";
+import { Transaction, TransactionContractInfo } from "@/types/data-type";
 import { formatDisplayPackagePath } from "@/common/utils/string-util";
 
 import * as S from "./TransactionContractDetails.styles";
@@ -11,7 +11,6 @@ import { DLWrap, FitContentA } from "@/components/ui/detail-page-common-styles";
 import Badge from "@/components/ui/badge";
 import Tooltip from "@/components/ui/tooltip";
 import IconTooltip from "@/assets/svgs/icon-tooltip.svg";
-import TransactionTransferContract from "../transaction-transfer-contract/TransactionTransferContract";
 import ShowLog from "@/components/ui/show-log";
 import { TransactionAddPackageContract } from "../transaction-add-package-contract/TransactionAddPackageContract";
 import { TransactionCallerContract } from "../transaction-caller-contract/TransactionCallerContract";
@@ -28,9 +27,10 @@ export const StandardNetworkTransactionContractDetails: React.FC<{
   transactionItem: TransactionContractInfo | Transaction | null;
   isDesktop: boolean;
   getUrlWithNetwork: (uri: string) => string;
-  getTokenAmount: (tokenId: string, amountRaw: string | number) => Amount;
-  getName?: (address: string) => string;
-}> = ({ transactionItem, isDesktop, getUrlWithNetwork, getTokenAmount }) => {
+
+  // TODO: [temporary] to be removed after API development is complete - rawContent prop
+  showLog?: string;
+}> = ({ transactionItem, isDesktop, getUrlWithNetwork, showLog }) => {
   const messages = React.useMemo(() => {
     if (!transactionItem?.messages) {
       return [];
@@ -149,9 +149,9 @@ export const StandardNetworkTransactionContractDetails: React.FC<{
           {hasCaller(message) && (
             <TransactionCallerContract message={message} isDesktop={isDesktop} getUrlWithNetwork={getUrlWithNetwork} />
           )}
-          {message["log"] && <ShowLog isTabLog={false} logData={message.log} btnTextType="Logs" />}
         </S.ContractListBox>
       ))}
+      {showLog && <ShowLog isTabLog={false} logData={showLog} btnTextType="Logs" />}
     </React.Fragment>
   );
 };

--- a/src/components/view/transaction/transaction-info/standard-network-transaction-info/StandardNetworkTransactionInfo.tsx
+++ b/src/components/view/transaction/transaction-info/standard-network-transaction-info/StandardNetworkTransactionInfo.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 
-import { Amount, GnoEvent, Transaction, TransactionContractInfo } from "@/types/data-type";
+import { GnoEvent, TransactionContractInfo } from "@/types/data-type";
 import { useGetTransactionEventsByHeight } from "@/common/react-query/transaction/api/use-get-transaction-events-by-hash";
 import { useGetTransactionContractsByHeight } from "@/common/react-query/transaction/api";
 import { TransactionMapper } from "@/common/mapper/transaction/transaction-mapper";
+import { useTransaction } from "@/common/hooks/transactions/use-transaction";
 
 import DataListSection from "@/components/view/details-data-section/data-list-section";
 import { StandardNetworkTransactionContractDetails } from "../../transaction-contract-details/StandardNetworkTransactionContractsDetails";
@@ -16,7 +17,6 @@ interface TransactionInfoProps {
   isDesktop: boolean;
   setCurrentTab: (tab: string) => void;
   getUrlWithNetwork: (uri: string) => string;
-  getTokenAmount: (tokenId: string, amountRaw: string | number) => Amount;
 }
 
 const StandardNetworkTransactionInfo = ({
@@ -25,8 +25,11 @@ const StandardNetworkTransactionInfo = ({
   currentTab,
   setCurrentTab,
   getUrlWithNetwork,
-  getTokenAmount,
 }: TransactionInfoProps) => {
+  // TODO: transactionItem.rawContent is temporary data. Needs to be removed after API development is complete
+  const { transaction } = useTransaction(txHash);
+  const { transactionItem } = transaction;
+
   const { data: contractsData, isFetched: isFetchedContractsData } = useGetTransactionContractsByHeight(txHash);
   const { data: eventsData, isFetched: isFetchedEventsData } = useGetTransactionEventsByHeight(txHash);
 
@@ -67,7 +70,8 @@ const StandardNetworkTransactionInfo = ({
           transactionItem={txContracts}
           isDesktop={isDesktop}
           getUrlWithNetwork={getUrlWithNetwork}
-          getTokenAmount={getTokenAmount}
+          // TODO: [temporary] to be removed after API development is complete - rawContent prop
+          showLog={transactionItem?.rawContent}
         />
       )}
       {currentTab === "Events" && <EventDatatable events={txEvents} isFetched={isFetchedEventsData} />}

--- a/src/containers/transaction/transaction-info-container/TransactionInfoContainer.tsx
+++ b/src/containers/transaction/transaction-info-container/TransactionInfoContainer.tsx
@@ -16,7 +16,7 @@ const TransactionInfoContainer = ({ txHash }: TransactionInfoContainerProps) => 
   const { isDesktop } = useWindowSize();
   const { isCustomNetwork } = useNetworkProvider();
 
-  const [currentTab, setCurrentTab] = React.useState("Contract");
+  const [currentTab, setCurrentTab] = React.useState("Messages");
 
   const { getUrlWithNetwork } = useNetwork();
   const { getTokenAmount } = useTokenMeta();
@@ -37,7 +37,6 @@ const TransactionInfoContainer = ({ txHash }: TransactionInfoContainerProps) => 
       setCurrentTab={setCurrentTab}
       isDesktop={isDesktop}
       getUrlWithNetwork={getUrlWithNetwork}
-      getTokenAmount={getTokenAmount}
     />
   );
 };


### PR DESCRIPTION
## Description
This PR is an action that replaces the ShowLog data on the transaction detail page with an existing value.

## Details
- transactionItem.rawContent
- Fixed Messages data not being exposed on the Tranasction Detail page
<img width="1259" alt="스크린샷 2025-05-10 오후 3 49 48" src="https://github.com/user-attachments/assets/b7247791-0368-49b3-926a-fbcb80d0c816" />