### PR TITLE
[GNS-286] ugnot -> GNOT convert

### DIFF
--- a/src/common/utils/native-token-utility.test.ts
+++ b/src/common/utils/native-token-utility.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { toGNOT } from "./native-token-utility";
+import { toGNOTAmount } from "./native-token-utility";
 
 jest.mock("../hooks/common/use-token-meta", () => ({
   GNOTToken: {
@@ -10,24 +10,24 @@ jest.mock("../hooks/common/use-token-meta", () => ({
   },
 }));
 
-describe("toGNOT", () => {
+describe("toGNOTAmount", () => {
   describe("when converting from ugnot", () => {
     it("should convert 1000000 ugnot to 1 GNOT", () => {
-      expect(toGNOT("1000000", "ugnot")).toEqual({
+      expect(toGNOTAmount("1000000", "ugnot")).toEqual({
         value: "1",
         denom: "GNOT",
       });
     });
 
     it("should convert 1 ugnot to 0.000001 GNOT", () => {
-      expect(toGNOT("1", "ugnot")).toEqual({
+      expect(toGNOTAmount("1", "ugnot")).toEqual({
         value: "0.000001",
         denom: "GNOT",
       });
     });
 
     it("should handle number type input", () => {
-      expect(toGNOT(1000000, "ugnot")).toEqual({
+      expect(toGNOTAmount(1000000, "ugnot")).toEqual({
         value: "1",
         denom: "GNOT",
       });
@@ -36,14 +36,14 @@ describe("toGNOT", () => {
 
   describe("when converting from non-ugnot denomination", () => {
     it("should keep original value and uppercase the denom", () => {
-      expect(toGNOT("100", "atom")).toEqual({
+      expect(toGNOTAmount("100", "atom")).toEqual({
         value: "100",
         denom: "ATOM",
       });
     });
 
     it("should trim and uppercase denom", () => {
-      expect(toGNOT("100", " atom ")).toEqual({
+      expect(toGNOTAmount("100", " atom ")).toEqual({
         value: "100",
         denom: "ATOM",
       });
@@ -52,21 +52,21 @@ describe("toGNOT", () => {
 
   describe("when handling different cases of ugnot", () => {
     it("should handle uppercase UGNOT", () => {
-      expect(toGNOT("1000000", "UGNOT")).toEqual({
+      expect(toGNOTAmount("1000000", "UGNOT")).toEqual({
         value: "1",
         denom: "GNOT",
       });
     });
 
     it("should handle mixed case UgNoT", () => {
-      expect(toGNOT("1000000", "UgNoT")).toEqual({
+      expect(toGNOTAmount("1000000", "UgNoT")).toEqual({
         value: "1",
         denom: "GNOT",
       });
     });
 
     it("should handle with spaces", () => {
-      expect(toGNOT("1000000", " ugnot ")).toEqual({
+      expect(toGNOTAmount("1000000", " ugnot ")).toEqual({
         value: "1",
         denom: "GNOT",
       });
@@ -75,18 +75,18 @@ describe("toGNOT", () => {
 
   describe("edge cases", () => {
     it("should handle zero", () => {
-      expect(toGNOT("0", "ugnot")).toEqual({
+      expect(toGNOTAmount("0", "ugnot")).toEqual({
         value: "0",
         denom: "GNOT",
       });
-      expect(toGNOT(0, "ugnot")).toEqual({
+      expect(toGNOTAmount(0, "ugnot")).toEqual({
         value: "0",
         denom: "GNOT",
       });
     });
 
     it("should handle empty string value", () => {
-      expect(toGNOT("", "ugnot")).toEqual({
+      expect(toGNOTAmount("", "ugnot")).toEqual({
         value: "0",
         denom: "GNOT",
       });
@@ -94,28 +94,28 @@ describe("toGNOT", () => {
 
     it("should handle very large numbers", () => {
       const largeNumber = "1000000000000000000000000";
-      expect(toGNOT(largeNumber, "ugnot")).toEqual({
+      expect(toGNOTAmount(largeNumber, "ugnot")).toEqual({
         value: new BigNumber(largeNumber).shiftedBy(-6).toString(),
         denom: "GNOT",
       });
     });
 
     it("should handle very small numbers", () => {
-      expect(toGNOT("0.000001", "ugnot")).toEqual({
+      expect(toGNOTAmount("0.000001", "ugnot")).toEqual({
         value: Number("0.000000000001").toString(),
         denom: "GNOT",
       });
     });
 
     it("should handle scientific notation", () => {
-      expect(toGNOT("1e6", "ugnot")).toEqual({
+      expect(toGNOTAmount("1e6", "ugnot")).toEqual({
         value: "1",
         denom: "GNOT",
       });
     });
 
     it("should handle negative numbers", () => {
-      expect(toGNOT("-1000000", "ugnot")).toEqual({
+      expect(toGNOTAmount("-1000000", "ugnot")).toEqual({
         value: "-1",
         denom: "GNOT",
       });
@@ -124,13 +124,13 @@ describe("toGNOT", () => {
     // null, undefined
     it("should handle null/undefined values", () => {
       // @ts-expect-error testing invalid denomination case
-      expect(toGNOT(null, "ugnot")).toEqual({
+      expect(toGNOTAmount(null, "ugnot")).toEqual({
         value: "0",
         denom: "GNOT",
       });
 
       // @ts-expect-error testing invalid value type
-      expect(toGNOT(undefined, "ugnot")).toEqual({
+      expect(toGNOTAmount(undefined, "ugnot")).toEqual({
         value: "0",
         denom: "GNOT",
       });

--- a/src/common/utils/native-token-utility.test.ts
+++ b/src/common/utils/native-token-utility.test.ts
@@ -1,0 +1,139 @@
+import BigNumber from "bignumber.js";
+import { toGNOT } from "./native-token-utility";
+
+jest.mock("../hooks/common/use-token-meta", () => ({
+  GNOTToken: {
+    name: "Gno.land",
+    denom: "ugnot",
+    symbol: "GNOT",
+    decimals: 6,
+  },
+}));
+
+describe("toGNOT", () => {
+  describe("when converting from ugnot", () => {
+    it("should convert 1000000 ugnot to 1 GNOT", () => {
+      expect(toGNOT("1000000", "ugnot")).toEqual({
+        value: "1",
+        denom: "GNOT",
+      });
+    });
+
+    it("should convert 1 ugnot to 0.000001 GNOT", () => {
+      expect(toGNOT("1", "ugnot")).toEqual({
+        value: "0.000001",
+        denom: "GNOT",
+      });
+    });
+
+    it("should handle number type input", () => {
+      expect(toGNOT(1000000, "ugnot")).toEqual({
+        value: "1",
+        denom: "GNOT",
+      });
+    });
+  });
+
+  describe("when converting from non-ugnot denomination", () => {
+    it("should keep original value and uppercase the denom", () => {
+      expect(toGNOT("100", "atom")).toEqual({
+        value: "100",
+        denom: "ATOM",
+      });
+    });
+
+    it("should trim and uppercase denom", () => {
+      expect(toGNOT("100", " atom ")).toEqual({
+        value: "100",
+        denom: "ATOM",
+      });
+    });
+  });
+
+  describe("when handling different cases of ugnot", () => {
+    it("should handle uppercase UGNOT", () => {
+      expect(toGNOT("1000000", "UGNOT")).toEqual({
+        value: "1",
+        denom: "GNOT",
+      });
+    });
+
+    it("should handle mixed case UgNoT", () => {
+      expect(toGNOT("1000000", "UgNoT")).toEqual({
+        value: "1",
+        denom: "GNOT",
+      });
+    });
+
+    it("should handle with spaces", () => {
+      expect(toGNOT("1000000", " ugnot ")).toEqual({
+        value: "1",
+        denom: "GNOT",
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle zero", () => {
+      expect(toGNOT("0", "ugnot")).toEqual({
+        value: "0",
+        denom: "GNOT",
+      });
+      expect(toGNOT(0, "ugnot")).toEqual({
+        value: "0",
+        denom: "GNOT",
+      });
+    });
+
+    it("should handle empty string value", () => {
+      expect(toGNOT("", "ugnot")).toEqual({
+        value: "0",
+        denom: "GNOT",
+      });
+    });
+
+    it("should handle very large numbers", () => {
+      const largeNumber = "1000000000000000000000000";
+      expect(toGNOT(largeNumber, "ugnot")).toEqual({
+        value: new BigNumber(largeNumber).shiftedBy(-6).toString(),
+        denom: "GNOT",
+      });
+    });
+
+    it("should handle very small numbers", () => {
+      expect(toGNOT("0.000001", "ugnot")).toEqual({
+        value: Number("0.000000000001").toString(),
+        denom: "GNOT",
+      });
+    });
+
+    it("should handle scientific notation", () => {
+      expect(toGNOT("1e6", "ugnot")).toEqual({
+        value: "1",
+        denom: "GNOT",
+      });
+    });
+
+    it("should handle negative numbers", () => {
+      expect(toGNOT("-1000000", "ugnot")).toEqual({
+        value: "-1",
+        denom: "GNOT",
+      });
+    });
+
+    // null, undefined
+    it("should handle null/undefined values", () => {
+      // @ts-expect-error testing invalid denomination case
+      expect(toGNOT(null, "ugnot")).toEqual({
+        value: "0",
+        denom: "GNOT",
+      });
+
+      // @ts-expect-error testing invalid value type
+      expect(toGNOT(undefined, "ugnot")).toEqual({
+        value: "0",
+        denom: "GNOT",
+      });
+    });
+  });
+});

--- a/src/common/utils/native-token-utility.ts
+++ b/src/common/utils/native-token-utility.ts
@@ -1,0 +1,36 @@
+import BigNumber from "bignumber.js";
+import { GNOTToken } from "../hooks/common/use-token-meta";
+import { Amount } from "@/types/data-type";
+
+type TokenValue = string | number;
+type TokenDenom = string;
+
+/**
+ * Convert given values and units to GNOT units
+ * @param value Value to convert
+ * @param denom Denom to convert
+ * @returns Interface: Amount
+ */
+export const toGNOT = (value: TokenValue, denom: TokenDenom): Amount => {
+  return {
+    value: convertAmountValue(value, denom),
+    denom: convertAmountDenom(denom),
+  };
+};
+
+export const convertAmountValue = (value: TokenValue, denom: TokenDenom): string => {
+  if (!value) return "0";
+
+  return isUgnot(denom)
+    ? new BigNumber(value).shiftedBy(-GNOTToken.decimals).toString()
+    : new BigNumber(value).toString();
+};
+
+export const convertAmountDenom = (denom: TokenDenom): string => {
+  return isUgnot(denom) ? GNOTToken.symbol : denom.toUpperCase().trim();
+};
+
+export const isUgnot = (denom: TokenDenom): boolean => {
+  const normalizeDenom = denom.toLowerCase().trim();
+  return normalizeDenom === GNOTToken.denom;
+};

--- a/src/common/utils/native-token-utility.ts
+++ b/src/common/utils/native-token-utility.ts
@@ -11,7 +11,7 @@ type TokenDenom = string;
  * @param denom Denom to convert
  * @returns Interface: Amount
  */
-export const toGNOT = (value: TokenValue, denom: TokenDenom): Amount => {
+export const toGNOTAmount = (value: TokenValue, denom: TokenDenom): Amount => {
   return {
     value: convertAmountValue(value, denom),
     denom: convertAmountDenom(denom),

--- a/src/components/view/datatable/realm-detail/realm-detail.tsx
+++ b/src/components/view/datatable/realm-detail/realm-detail.tsx
@@ -12,6 +12,7 @@ import { useRecoilValue } from "recoil";
 import { themeState } from "@/states";
 import { useTokenMeta } from "@/common/hooks/common/use-token-meta";
 import { Transaction } from "@/types/data-type";
+import { toGNOTAmount } from "@/common/utils/native-token-utility";
 
 interface Props {
   pkgPath: string;
@@ -127,7 +128,7 @@ export const RealmDetailDatatable = ({ pkgPath, data, isFetched, hasNextPage, ne
       .name("Fee")
       .width(113)
       .className("fee")
-      .renderOption(fee => <DatatableItem.Amount {...getTokenAmount(fee.denom, fee.value)} />)
+      .renderOption(fee => <DatatableItem.Amount {...toGNOTAmount(fee.value, fee.denom)} />)
       .build();
   };
 

--- a/src/components/view/datatable/token-detail/token-detail-page.tsx
+++ b/src/components/view/datatable/token-detail/token-detail-page.tsx
@@ -10,6 +10,7 @@ import { useRecoilValue } from "recoil";
 import { themeState } from "@/states";
 import { useTokenMeta } from "@/common/hooks/common/use-token-meta";
 import { useGetTokenTransactionsByid } from "@/common/react-query/token/api";
+import { toGNOTAmount } from "@/common/utils/native-token-utility";
 
 import { Transaction } from "@/types/data-type";
 import { TokenTransactionModel } from "@/models/api/token/token-model";
@@ -130,7 +131,7 @@ export const TokenDetailDatatablePage = ({ path }: Props) => {
         data.numOfMessage > 1 ? (
           <DatatableItem.HasLink text="More" path={`/transactions/details?txhash=${data.hash}`} />
         ) : (
-          <DatatableItem.Amount {...getTokenAmount(amount.denom, amount.value)} />
+          <DatatableItem.Amount {...toGNOTAmount(amount.value, amount.denom)} />
         ),
       )
       .build();
@@ -152,7 +153,7 @@ export const TokenDetailDatatablePage = ({ path }: Props) => {
       .name("Fee")
       .width(113)
       .className("fee")
-      .renderOption(fee => <DatatableItem.Amount {...getTokenAmount(fee.denom, fee.value)} />)
+      .renderOption(fee => <DatatableItem.Amount {...toGNOTAmount(fee.value, fee.denom)} />)
       .build();
   };
 

--- a/src/components/view/realm/realm-summary/StandardNetworkRealmSummary.tsx
+++ b/src/components/view/realm/realm-summary/StandardNetworkRealmSummary.tsx
@@ -3,13 +3,14 @@ import Link from "next/link";
 
 import { formatDisplayPackagePath } from "@/common/utils/string-util";
 import { NonMobile } from "@/common/hooks/use-media";
-import { RealmSummary } from "@/types/data-type";
+import { Amount, RealmSummary } from "@/types/data-type";
 import { makeTemplate } from "@/common/utils/template.utils";
 import { GNOSTUDIO_REALM_FUNCTION_TEMPLATE, GNOSTUDIO_REALM_TEMPLATE } from "@/common/values/url.constant";
-import { useTokenMeta } from "@/common/hooks/common/use-token-meta";
+import { GNOTToken } from "@/common/hooks/common/use-token-meta";
 import { useNetwork } from "@/common/hooks/use-network";
 import { useGetRealmByPath } from "@/common/react-query/realm/api";
 import { RealmMapper } from "@/common/mapper/realm/realm-mapper";
+import { toGNOTAmount } from "@/common/utils/native-token-utility";
 
 import IconTooltip from "@/assets/svgs/icon-tooltip.svg";
 import IconCopy from "@/assets/svgs/icon-copy.svg";
@@ -45,7 +46,6 @@ const TOOLTIP_BALANCE = (
 
 const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => {
   const { currentNetwork, getUrlWithNetwork } = useNetwork();
-  const { getTokenAmount } = useTokenMeta();
 
   const { data: realmData, isFetched: isFetchedRealmData } = useGetRealmByPath(path);
 
@@ -54,6 +54,20 @@ const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => 
 
     return RealmMapper.realmSummaryFromApiResponse(realmData.data);
   }, [realmData?.data]);
+
+  const realmBalance: Amount | null = React.useMemo(() => {
+    if (!realmSummary?.balance) return null;
+
+    const data = realmSummary.balance;
+    return toGNOTAmount(data.value, data.denom);
+  }, [realmSummary?.balance]);
+
+  const realmTotalUsedFees: Amount | null = React.useMemo(() => {
+    if (!realmSummary?.totalUsedFees) return null;
+
+    const data = realmSummary.totalUsedFees;
+    return toGNOTAmount(data?.value, data?.denom);
+  }, [realmSummary?.totalUsedFees]);
 
   const moveGnoStudioViewRealm = React.useCallback(() => {
     if (!currentNetwork) {
@@ -221,8 +235,8 @@ const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => 
             <AmountText
               minSize="body1"
               maxSize="p4"
-              value={realmSummary?.balance?.value || "0"}
-              denom={realmSummary?.balance?.denom || "0"}
+              value={realmBalance?.value || "0"}
+              denom={realmBalance?.denom || GNOTToken.symbol}
             />
           </Badge>
         </dd>
@@ -240,8 +254,8 @@ const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => 
             <AmountText
               minSize="body1"
               maxSize="p4"
-              value={realmSummary?.totalUsedFees?.value || "0"}
-              denom={realmSummary?.totalUsedFees?.denom || "0"}
+              value={realmTotalUsedFees?.value || "0"}
+              denom={realmTotalUsedFees?.denom || GNOTToken.symbol}
             />
           </Badge>
         </dd>

--- a/src/components/view/realms/realm-list-table/standard-network-realm-list-table/StandardNetworkRealmListTable.tsx
+++ b/src/components/view/realms/realm-list-table/standard-network-realm-list-table/StandardNetworkRealmListTable.tsx
@@ -8,6 +8,7 @@ import { DEVICE_TYPE } from "@/common/values/ui.constant";
 import { themeState } from "@/states";
 import { RealmListSortOption } from "@/common/types/realm";
 import { Realm } from "@/types/data-type";
+import { toGNOTAmount } from "@/common/utils/native-token-utility";
 
 import * as S from "./StandardNetworkRealmListTable.styles";
 import Datatable, { DatatableOption } from "@/components/ui/datatable";
@@ -108,7 +109,7 @@ export const StandardNetworkRealmListTable = ({
       .name("Total Gas Used")
       .width(163)
       .renderOption(gasUsed => {
-        return <AmountText value={gasUsed.value} denom={gasUsed.denom?.toUpperCase()} maxSize="p4" minSize="body1" />;
+        return <AmountText {...toGNOTAmount(gasUsed.value, gasUsed.denom)} maxSize="p4" minSize="body1" />;
       })
       .build();
   };

--- a/src/components/view/transaction/transaction-summary/standard-network-transaction-summary/StandardNetworkTransactionSummary.tsx
+++ b/src/components/view/transaction/transaction-summary/standard-network-transaction-summary/StandardNetworkTransactionSummary.tsx
@@ -12,6 +12,9 @@ import ShowLog from "@/components/ui/show-log";
 import { StyledIconCopy } from "../Transaction.styles";
 import TableSkeleton from "@/components/view/common/table-skeleton/TableSkeleton";
 import { useMappedApiTransaction } from "@/common/services/transaction/use-mapped-api-transaction";
+import { Amount } from "@/types/data-type";
+import { toGNOTAmount } from "@/common/utils/native-token-utility";
+import { GNOTToken } from "@/common/hooks/common/use-token-meta";
 
 interface TransactionSummaryProps {
   isDesktop: boolean;
@@ -33,6 +36,13 @@ const StandardNetworkTransactionSummary = ({ isDesktop, txHash, getUrlWithNetwor
       return null;
     }
   }, [data.transactionItem, data.blockResult]);
+
+  const transactionFee: Amount | null = React.useMemo(() => {
+    if (!data?.transactionItem?.fee) return null;
+
+    const fee = data.transactionItem.fee;
+    return toGNOTAmount(fee.value, fee.denom);
+  }, [data?.transactionItem?.fee]);
 
   if (!isFetched) return <TableSkeleton />;
 
@@ -100,8 +110,8 @@ const StandardNetworkTransactionSummary = ({ isDesktop, txHash, getUrlWithNetwor
               <AmountText
                 minSize="body2"
                 maxSize="p4"
-                value={data.transactionItem.fee.value}
-                denom={data.transactionItem.fee.denom}
+                value={transactionFee?.value || "0"}
+                denom={transactionFee?.denom || GNOTToken.symbol}
               />
             </Badge>
           </dd>

--- a/src/components/view/transaction/transaction-transfer-contract/StandardNetworkTransferContract.tsx
+++ b/src/components/view/transaction/transaction-transfer-contract/StandardNetworkTransferContract.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { v1 } from "uuid";
 
 import { GNOTToken } from "@/common/hooks/common/use-token-meta";
-import { parseTokenAmount } from "@/common/utils/token.utility";
+import { toGNOTAmount } from "@/common/utils/native-token-utility";
 
 import * as S from "./TransactionTransferContract.styles";
 import Text from "@/components/ui/text";
@@ -33,13 +33,24 @@ const StandardNetworkTransactionTransferContract = ({
     return message?.to || "-";
   }, [message]);
 
+  const amount: Amount | null = React.useMemo(() => {
+    if (!message?.amount) return null;
+
+    return toGNOTAmount(message.amount.value, message.amount.denom);
+  }, [message?.amount]);
+
   return (
     <>
       <DLWrap desktop={isDesktop}>
         <dt>Amount</dt>
         <dd>
           <Badge>
-            <AmountText minSize="body2" maxSize="p4" {...message.amount} />
+            <AmountText
+              minSize="body2"
+              maxSize="p4"
+              value={amount?.value || "0"}
+              denom={amount?.denom || GNOTToken.symbol}
+            />
           </Badge>
         </dd>
       </DLWrap>

--- a/src/components/view/transactions/transaction-list-table/standard-network/StandardNetworkTransactionListTable.tsx
+++ b/src/components/view/transactions/transaction-list-table/standard-network/StandardNetworkTransactionListTable.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from "recoil";
 
 import { DEVICE_TYPE } from "@/common/values/ui.constant";
 import { themeState } from "@/states";
-import { useTokenMeta } from "@/common/hooks/common/use-token-meta";
+import { toGNOTAmount } from "@/common/utils/native-token-utility";
 
 import * as S from "./StandardNetworkTransactionListTable.styles";
 import Datatable, { DatatableOption } from "@/components/ui/datatable";
@@ -51,7 +51,6 @@ export const StandardNetworkTransactionListTable = ({
 }: StandardNetworkTransactionListTableProps) => {
   const themeMode = useRecoilValue(themeState);
 
-  const { getTokenAmount } = useTokenMeta();
   const [development, setDevelopment] = useState(false);
 
   useEffect(() => {
@@ -157,7 +156,7 @@ export const StandardNetworkTransactionListTable = ({
         data.numOfMessage > 1 ? (
           <DatatableItem.HasLink text="More" path={`/transactions/details?txhash=${data.txHash}`} />
         ) : (
-          <DatatableItem.Amount {...getTokenAmount(data.amount.denom, data.amount.value)} />
+          <DatatableItem.Amount {...toGNOTAmount(data.amount.value, data.amount.denom)} />
         ),
       )
       .build();
@@ -179,7 +178,7 @@ export const StandardNetworkTransactionListTable = ({
       .name("Fee")
       .width(113)
       .className("fee")
-      .renderOption(fee => <DatatableItem.Amount {...getTokenAmount(fee.denom, fee.value)} />)
+      .renderOption(fee => <DatatableItem.Amount {...toGNOTAmount(fee.value, fee.denom)} />)
       .build();
   };
 


### PR DESCRIPTION
## Description
Created a utility function `toGNOTAmount` to standardize the conversion and display of transaction fees across all transaction-related components.

## Details
- Added `toGNOTAmount` utility function in `native-token-utility.ts`
- Applied consistent GNOT conversion across all transaction components
- Added proper null checks and fallback values for fee display
- Ensured consistent denomination display as GNOT- 
- Added test coverage:
  - Unit tests for `toGNOTAmount` utility