### PR TITLE
feat: add open gno web in realm page

### DIFF
--- a/public/resource/chains.json
+++ b/public/resource/chains.json
@@ -4,13 +4,15 @@
     "chainId": "test6",
     "apiUrl": "https://dev.api.onbloc.xyz/v1",
     "rpcUrl": "https://test6.onbloc.xyz:443",
-    "indexerUrl": "https://test6.indexer.onbloc.xyz"
+    "indexerUrl": "https://test6.indexer.onbloc.xyz",
+    "gnoWebUrl": "https://test6.testnets.gno.land"
   },
   {
     "name": "Portal Loop",
     "chainId": "portal-loop",
     "apiUrl": "https://staging.api.onbloc.xyz/v1",
     "rpcUrl": "https://rpc.gno.land:443",
-    "indexerUrl": "https://indexer.onbloc.xyz"
+    "indexerUrl": "https://indexer.onbloc.xyz",
+    "gnoWebUrl": "https://gno.land"
   }
 ]

--- a/src/common/hooks/use-network.tsx
+++ b/src/common/hooks/use-network.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NetworkState } from "@/states";
+import { useRouter } from "next/router";
+import ChainData from "public/resource/chains.json";
 import React, { useMemo } from "react";
 import { useRecoilState } from "recoil";
-import ChainData from "public/resource/chains.json";
-import { useRouter } from "next/router";
 import { makeQueryString } from "../utils/string-util";
 
 type NetworkTransitionState = {
@@ -71,6 +71,14 @@ export const useNetwork = () => {
     };
   }, [currentNetwork]);
 
+  const gnoWebUrl = useMemo(() => {
+    if (!currentNetwork) {
+      return null;
+    }
+
+    return currentNetwork.gnoWebUrl || null;
+  }, [currentNetwork]);
+
   React.useEffect(() => {
     return () => {
       const { timerId } = networkTransitionRef.current;
@@ -107,6 +115,7 @@ export const useNetwork = () => {
       apiUrl: chain.apiUrl,
       rpcUrl: chain.rpcUrl,
       indexerUrl: chain.indexerUrl,
+      gnoWebUrl: chain.gnoWebUrl,
     });
 
     const uri = window.location.pathname + window.location.search;
@@ -124,6 +133,7 @@ export const useNetwork = () => {
       apiUrl: "",
       rpcUrl,
       indexerUrl,
+      gnoWebUrl: null,
     });
 
     const uri = window.location.pathname + window.location.search;
@@ -141,6 +151,7 @@ export const useNetwork = () => {
 
   return {
     currentNetwork,
+    gnoWebUrl,
     getUrlWithNetwork,
     setCurrentNetwork,
     changeNetwork,

--- a/src/common/values/url.constant.ts
+++ b/src/common/values/url.constant.ts
@@ -1,5 +1,8 @@
 export const GNOSTUDIO_BASE_URL = "https://gno.studio" as const;
 
+// template variable is [GNOWEB_URL] and [PACKAGE_POST_PATH]
+export const GNOWEB_REALM_TEMPLATE = "[GNOWEB_URL][PACKAGE_POST_PATH]" as const;
+
 // template variable is [PACKAGE_PATH] and [NETWORK]
 export const GNOSTUDIO_REALM_TEMPLATE = `${GNOSTUDIO_BASE_URL}/connect/view/[PACKAGE_PATH]?network=[NETWORK]` as const;
 

--- a/src/components/view/realm/realm-summary/StandardNetworkRealmSummary.tsx
+++ b/src/components/view/realm/realm-summary/StandardNetworkRealmSummary.tsx
@@ -1,29 +1,34 @@
-import React from "react";
 import Link from "next/link";
+import React from "react";
 
-import { formatDisplayPackagePath } from "@/common/utils/string-util";
-import { NonMobile } from "@/common/hooks/use-media";
-import { Amount, RealmSummary } from "@/types/data-type";
-import { makeTemplate } from "@/common/utils/template.utils";
-import { GNOSTUDIO_REALM_FUNCTION_TEMPLATE, GNOSTUDIO_REALM_TEMPLATE } from "@/common/values/url.constant";
 import { GNOTToken } from "@/common/hooks/common/use-token-meta";
+import { NonMobile } from "@/common/hooks/use-media";
 import { useNetwork } from "@/common/hooks/use-network";
-import { useGetRealmByPath } from "@/common/react-query/realm/api";
 import { RealmMapper } from "@/common/mapper/realm/realm-mapper";
+import { useGetRealmByPath } from "@/common/react-query/realm/api";
 import { toGNOTAmount } from "@/common/utils/native-token-utility";
+import { formatDisplayPackagePath } from "@/common/utils/string-util";
+import { makeTemplate } from "@/common/utils/template.utils";
+import {
+  GNOSTUDIO_REALM_FUNCTION_TEMPLATE,
+  GNOSTUDIO_REALM_TEMPLATE,
+  GNOWEB_REALM_TEMPLATE,
+} from "@/common/values/url.constant";
+import { Amount, RealmSummary } from "@/types/data-type";
 
-import IconTooltip from "@/assets/svgs/icon-tooltip.svg";
 import IconCopy from "@/assets/svgs/icon-copy.svg";
 import IconLink from "@/assets/svgs/icon-link.svg";
-import DataSection from "../../details-data-section";
-import { DLWrap, FitContentA, LinkWrapper } from "@/components/ui/detail-page-common-styles";
-import Badge from "@/components/ui/badge";
-import Tooltip from "@/components/ui/tooltip";
-import Text from "@/components/ui/text";
-import ShowLog from "@/components/ui/show-log";
-import TableSkeleton from "../../common/table-skeleton/TableSkeleton";
-import { AmountText } from "@/components/ui/text/amount-text";
+import IconTooltip from "@/assets/svgs/icon-tooltip.svg";
 import { formatDisplayBlockHeight } from "@/common/utils/block.utility";
+import { GNO_NETWORK_PREFIXES } from "@/common/values/gno.constant";
+import Badge from "@/components/ui/badge";
+import { DLWrap, FitContentA, LinkWrapper } from "@/components/ui/detail-page-common-styles";
+import ShowLog from "@/components/ui/show-log";
+import Text from "@/components/ui/text";
+import { AmountText } from "@/components/ui/text/amount-text";
+import Tooltip from "@/components/ui/tooltip";
+import TableSkeleton from "../../common/table-skeleton/TableSkeleton";
+import DataSection from "../../details-data-section";
 
 interface RealmSummaryProps {
   path: string;
@@ -46,7 +51,7 @@ const TOOLTIP_BALANCE = (
 );
 
 const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => {
-  const { currentNetwork, getUrlWithNetwork } = useNetwork();
+  const { currentNetwork, gnoWebUrl, getUrlWithNetwork } = useNetwork();
 
   const { data: realmData, isFetched: isFetchedRealmData } = useGetRealmByPath(path);
 
@@ -69,6 +74,26 @@ const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => 
     const data = realmSummary.totalUsedFees;
     return toGNOTAmount(data?.value, data?.denom);
   }, [realmSummary?.totalUsedFees]);
+
+  const hasGnoWebUrl = React.useMemo(() => {
+    return gnoWebUrl !== null && gnoWebUrl !== "";
+  }, [gnoWebUrl]);
+
+  const moveGnoWeb = React.useCallback(() => {
+    if (!gnoWebUrl) {
+      return;
+    }
+
+    const packagePostPath = path.startsWith(GNO_NETWORK_PREFIXES.GNO_LAND)
+      ? path.replace(GNO_NETWORK_PREFIXES.GNO_LAND, "")
+      : path;
+
+    const url = makeTemplate(GNOWEB_REALM_TEMPLATE, {
+      GNOWEB_URL: gnoWebUrl,
+      PACKAGE_POST_PATH: packagePostPath,
+    });
+    window.open(url, "_blank");
+  }, [path, gnoWebUrl]);
 
   const moveGnoStudioViewRealm = React.useCallback(() => {
     if (!currentNetwork) {
@@ -139,6 +164,15 @@ const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => 
           </Badge>
 
           <NonMobile>
+            {hasGnoWebUrl && (
+              <LinkWrapper onClick={moveGnoWeb}>
+                <Text type="p4" className="ellipsis">
+                  Go to Gnoweb
+                </Text>
+                <IconLink className="icon-link" />
+              </LinkWrapper>
+            )}
+
             <LinkWrapper onClick={moveGnoStudioViewRealm}>
               <Text type="p4" className="ellipsis">
                 Try in GnoStudio

--- a/src/models/chain-model.ts
+++ b/src/models/chain-model.ts
@@ -8,6 +8,8 @@ export interface ChainModel {
   rpcUrl: string | null;
 
   indexerUrl: string | null;
+
+  gnoWebUrl?: string | null;
 }
 
 export type ChainSupportType = "ALL" | "RPC_WITH_INDEXER" | "RPC" | "NONE";

--- a/src/providers/network-provider.tsx
+++ b/src/providers/network-provider.tsx
@@ -1,14 +1,14 @@
 "use client";
 import { useRouter } from "@/common/hooks/common/use-router";
-import { createContext, useEffect, useMemo, useState } from "react";
 import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
+import { createContext, useEffect, useMemo } from "react";
 
-import { RPCClient } from "@/common/clients/rpc-client";
 import { IndexerClient } from "@/common/clients/indexer-client/indexer-client";
-import { AxiosClient } from "@/common/clients/network-client/axios-client";
 import { NetworkClient } from "@/common/clients/network-client";
-import { HttpRPCClient } from "@/common/clients/rpc-client/http-rpc-client";
+import { AxiosClient } from "@/common/clients/network-client/axios-client";
 import { NodeRPCClient } from "@/common/clients/node-client";
+import { RPCClient } from "@/common/clients/rpc-client";
+import { HttpRPCClient } from "@/common/clients/rpc-client/http-rpc-client";
 
 import { useNetwork } from "@/common/hooks/use-network";
 import { ChainModel, getChainSupportType } from "@/models/chain-model";
@@ -56,6 +56,7 @@ const NetworkProvider: React.FC<React.PropsWithChildren<NetworkProviderPros>> = 
           apiUrl: "",
           rpcUrl: router.query?.rpcUrl?.toString() || "",
           indexerUrl: router.query?.indexerUrl?.toString() || "",
+          gnoWebUrl: null,
         });
         return;
       }
@@ -66,9 +67,10 @@ const NetworkProvider: React.FC<React.PropsWithChildren<NetworkProviderPros>> = 
         apiUrl: chain.apiUrl || "",
         rpcUrl: chain.rpcUrl || "",
         indexerUrl: chain.indexerUrl || "",
+        gnoWebUrl: chain?.gnoWebUrl || null,
       });
     }
-  }, [router.query, currentNetwork]);
+  }, [router.query, currentNetwork, chains]);
 
   const currentNetworkModel: ChainModel | null = useMemo(() => {
     if (!currentNetwork) {

--- a/src/states/network.ts
+++ b/src/states/network.ts
@@ -7,6 +7,7 @@ export const currentNetwork = atom<{
   apiUrl: string;
   rpcUrl: string;
   indexerUrl: string;
+  gnoWebUrl: string | null;
 } | null>({
   key: `network/currentNetwork/${v1()}`,
   default: null,


### PR DESCRIPTION
## Description
This PR adds the ability to open realms directly in GnoWeb from the realm page. Users can now easily navigate between GnoScan and GnoWeb for a better development experience.

## Changes
- Added `gnoWebUrl` field to chain configuration
- Implemented GnoWeb URL generation in `useNetwork` hook
- Added GnoWeb link button in realm summary section
- Added necessary types and constants for GnoWeb integration

## Technical Details
- Added `gnoWebUrl` to `ChainModel` interface
- Created `GNOWEB_REALM_TEMPLATE` constant for URL generation
- Implemented URL transformation logic for GnoLand paths
- Added conditional rendering for GnoWeb link based on network support
