### PR TITLE
[GNS-279] vmCall Transfer Amount

### DIFF
--- a/src/common/hooks/tokens/use-token-meta-amount.ts
+++ b/src/common/hooks/tokens/use-token-meta-amount.ts
@@ -1,0 +1,26 @@
+import React from "react";
+import { useGetTokenMetaByPath } from "@/common/react-query/token/api/use-get-token-meta-by-path";
+import { Amount } from "@/types/data-type";
+import { makeDisplayTokenAmount } from "@/common/utils/string-util";
+import { toGNOTAmount } from "@/common/utils/native-token-utility";
+
+export function useTokenMetaAmount(amountInfo?: Amount) {
+  const denom = amountInfo?.denom || null;
+
+  const { data: tokenMeta, isLoading, isFetched } = useGetTokenMetaByPath(denom || "");
+
+  const amount: Amount | null = React.useMemo(() => {
+    if (!amountInfo) return null;
+
+    if (tokenMeta?.data && tokenMeta.data.decimals !== undefined) {
+      return {
+        denom: tokenMeta.data?.symbol || amountInfo.denom,
+        value: makeDisplayTokenAmount(amountInfo.value, tokenMeta.data.decimals),
+      };
+    }
+
+    return toGNOTAmount(amountInfo.value, amountInfo.denom);
+  }, [amountInfo, tokenMeta?.data]);
+
+  return { amount, isLoading, isFetched };
+}

--- a/src/common/react-query/query-keys.ts
+++ b/src/common/react-query/query-keys.ts
@@ -26,6 +26,7 @@ export enum QUERY_KEY {
   getTokens = "api_get_tokens",
   getTokenById = "api_get_token_by_id",
   getTokenTransactionsById = "api_get_token_transactions_by_id",
+  getTokenMetaByPath = "api_get_token_meta_by_path",
 
   // statistics
   getLatestBlogs = "api_get_latest_blogs",

--- a/src/common/react-query/token/api/use-get-token-meta-by-path.ts
+++ b/src/common/react-query/token/api/use-get-token-meta-by-path.ts
@@ -1,0 +1,22 @@
+import { UseQueryOptions } from "react-query";
+
+import { QUERY_KEY } from "@/common/react-query/query-keys";
+import { useServiceProvider } from "@/common/hooks/provider/use-service-provider";
+import { GetTokenMetaByPathResponse } from "@/repositories/api/token/response";
+import { useApiRepositoryQuery } from "@/common/react-query/hoc/api";
+import { API_REPOSITORY_KEY } from "@/common/values/query.constant";
+
+export const useGetTokenMetaByPath = (
+  path: string,
+  options?: UseQueryOptions<GetTokenMetaByPathResponse, Error, GetTokenMetaByPathResponse>,
+) => {
+  const { apiTokenRepository } = useServiceProvider();
+
+  return useApiRepositoryQuery(
+    [QUERY_KEY.getTokenMetaByPath, path],
+    apiTokenRepository,
+    API_REPOSITORY_KEY.TOKEN_REPOSITORY,
+    repository => repository.getTokenMetaByPath(path),
+    { ...options, enabled: !!path },
+  );
+};

--- a/src/components/view/transaction/transaction-info/standard-network-transaction-info/StandardNetworkTransactionInfo.tsx
+++ b/src/components/view/transaction/transaction-info/standard-network-transaction-info/StandardNetworkTransactionInfo.tsx
@@ -62,8 +62,6 @@ const StandardNetworkTransactionInfo = ({
     ];
   }, [eventsData]);
 
-  console.log(isFetchedContractsData, isFetchedEventsData, "?????");
-
   if (!isFetchedContractsData || !isFetchedEventsData) return <TableSkeleton />;
 
   return (

--- a/src/components/view/transaction/transaction-message-card/transaction-msg-call-message/StandardNetworkMsgCallMessage.tsx
+++ b/src/components/view/transaction/transaction-message-card/transaction-msg-call-message/StandardNetworkMsgCallMessage.tsx
@@ -1,11 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 
-import { GNOTToken } from "@/common/hooks/common/use-token-meta";
-import { toGNOTAmount } from "@/common/utils/native-token-utility";
 import { TransactionContractModel } from "@/repositories/api/transaction/response";
 import { MESSAGE_TYPES, TRANSACTION_FUNCTION_TYPES } from "@/common/values/message-types.constant";
-import { Amount } from "@/types/data-type";
 import { getTransactionMessageType } from "@/common/utils/message.utility";
 import { TOOLTIP_PACKAGE_PATH } from "@/common/values/tooltip-content.constant";
 
@@ -18,8 +15,8 @@ import {
   BadgeList,
   AmountBadge,
 } from "@/components/view/transaction/common";
-import { AmountText } from "@/components/ui/text/amount-text";
-import Badge from "@/components/ui/badge";
+import { useTokenMetaAmount } from "@/common/hooks/tokens/use-token-meta-amount";
+import { SkeletonBar } from "@/components/ui/loading/skeleton-bar";
 
 interface TransactionTransferContractProps {
   message: TransactionContractModel;
@@ -28,15 +25,9 @@ interface TransactionTransferContractProps {
 }
 
 const StandardNetworkMsgCallMessage = ({ isDesktop, message, getUrlWithNetwork }: TransactionTransferContractProps) => {
-  const creator = React.useMemo(() => {
-    return message?.caller || "-";
-  }, [message]);
+  const creator = message?.caller || "-";
 
-  const amount: Amount | null = React.useMemo(() => {
-    if (!message?.amount) return null;
-
-    return toGNOTAmount(message.amount.value, message.amount.denom);
-  }, [message?.amount]);
+  const { amount, isFetched, isLoading } = useTokenMetaAmount(message?.amount);
 
   const isTransferType = message.funcType === TRANSACTION_FUNCTION_TYPES.TRANSFER;
 
@@ -61,14 +52,8 @@ const StandardNetworkMsgCallMessage = ({ isDesktop, message, getUrlWithNetwork }
   const transferFields = (
     <>
       <Field label="Amount" isDesktop={isDesktop}>
-        <Badge>
-          <AmountText
-            minSize="body2"
-            maxSize="p4"
-            value={amount?.value || "0"}
-            denom={amount?.denom || GNOTToken.symbol}
-          />
-        </Badge>
+        {isLoading && <SkeletonBar width={80} />}
+        {!isLoading && isFetched && <AmountBadge amount={amount} />}
       </Field>
 
       <Field label="Caller (From)" isDesktop={isDesktop}>

--- a/src/repositories/api/token/api-token-repository-impl.ts
+++ b/src/repositories/api/token/api-token-repository-impl.ts
@@ -2,7 +2,12 @@ import { NetworkClient } from "@/common/clients/network-client";
 import { ApiTokenRepository } from "./api-token-repository";
 
 import { GetTokensRequestParameters, GetTokenTransactionsRequest } from "./request";
-import { GetTokenResponse, GetTokensResponse, GetTokenTransactionsResponse } from "./response";
+import {
+  GetTokenMetaByPathResponse,
+  GetTokenResponse,
+  GetTokensResponse,
+  GetTokenTransactionsResponse,
+} from "./response";
 import { makeQueryParameter } from "@/common/utils/string-util";
 import { CommonError } from "@/common/errors";
 
@@ -57,6 +62,20 @@ export class ApiTokenRepositoryImpl implements ApiTokenRepository {
     return this.networkClient
       .get<APIResponse<GetTokenTransactionsResponse>>({
         url: `tokens/${encodeURIComponent(path)}/transactions${requestParams}`,
+      })
+      .then(result => {
+        return result.data?.data;
+      });
+  }
+
+  getTokenMetaByPath(path: string): Promise<GetTokenMetaByPathResponse> {
+    if (!this.networkClient) {
+      throw new CommonError("FAILED_INITIALIZE_PROVIDER", "NetworkClient");
+    }
+
+    return this.networkClient
+      .get<APIResponse<GetTokenMetaByPathResponse>>({
+        url: `token-meta/${encodeURIComponent(path)}`,
       })
       .then(result => {
         return result.data?.data;

--- a/src/repositories/api/token/api-token-repository.ts
+++ b/src/repositories/api/token/api-token-repository.ts
@@ -1,5 +1,10 @@
 import { GetTokensRequestParameters, GetTokenTransactionsRequest } from "./request";
-import { GetTokenResponse, GetTokensResponse, GetTokenTransactionsResponse } from "./response";
+import {
+  GetTokenMetaByPathResponse,
+  GetTokenResponse,
+  GetTokensResponse,
+  GetTokenTransactionsResponse,
+} from "./response";
 
 export interface ApiTokenRepository {
   getTokens(params: GetTokensRequestParameters): Promise<GetTokensResponse>;
@@ -7,4 +12,6 @@ export interface ApiTokenRepository {
   getToken(tokenId: string): Promise<GetTokenResponse>;
 
   getTokenTransactions(params: GetTokenTransactionsRequest): Promise<GetTokenTransactionsResponse>;
+
+  getTokenMetaByPath(path: string): Promise<GetTokenMetaByPathResponse>;
 }

--- a/src/repositories/api/token/response/get-token-meta-by-path-response.ts
+++ b/src/repositories/api/token/response/get-token-meta-by-path-response.ts
@@ -1,0 +1,12 @@
+export interface TokenMeta {
+  tokenType: "Native" | "GRC20";
+  path: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  logoUrl: string | null;
+}
+
+export interface GetTokenMetaByPathResponse {
+  data: TokenMeta;
+}

--- a/src/repositories/api/token/response/index.ts
+++ b/src/repositories/api/token/response/index.ts
@@ -1,3 +1,4 @@
 export * from "./get-tokens-response";
 export * from "./get-token-response";
 export * from "./get-token-transactions-response";
+export * from "./get-token-meta-by-path-response";


### PR DESCRIPTION
## Description
This PR calls the token-meta API to refine the Transfer Amount data.

## Details
- Added useTokenAmount custom hook for token amount formatting
- Fetches token metadata (symbol, decimals) from API for accurate display
- Supports GRC20 tokens with different decimal places (e.g., PEPE with 4 decimals)
- Maintains consistent display format across the application

