### PR TITLE
refactor: update homepage supply tooltips

### DIFF
--- a/src/components/view/main-card/cards/supply/CustomNetworkSupplyCard.tsx
+++ b/src/components/view/main-card/cards/supply/CustomNetworkSupplyCard.tsx
@@ -31,10 +31,7 @@ export const CustomNetworkSupplyCard = () => {
             <Text type="p4" color="tertiary">
               Airdrop Supply
             </Text>
-            <Tooltip
-              width={215}
-              content="Estimated supply of GNOTs to be airdropped. This number is not final, and is subject to change."
-            >
+            <Tooltip width={215} content="Total GNOTs to be airdropped to Cosmos and AtomOne holders.">
               <Button width="16px" height="16px" radius="50%" bgColor="surface">
                 <IconInfo className="svg-info" />
               </Button>
@@ -58,7 +55,7 @@ export const CustomNetworkSupplyCard = () => {
             <Text type="p4" color="tertiary">
               Airdrop&nbsp;Holders
             </Text>
-            <Tooltip content="Total number of holders eligible for the GNOT airdrop. This number is not final and is subject to change.">
+            <Tooltip content="Total number of holders receiving 1 GNOT or more.">
               <Button width="16px" height="16px" radius="50%" bgColor="surface">
                 <IconInfo className="svg-info" />
               </Button>

--- a/src/components/view/main-card/cards/supply/StandardNetworkSupplyCard.tsx
+++ b/src/components/view/main-card/cards/supply/StandardNetworkSupplyCard.tsx
@@ -43,10 +43,7 @@ export const StandardNetworkSupplyCard = () => {
             <Text type="p4" color="tertiary">
               Airdrop Supply
             </Text>
-            <Tooltip
-              width={215}
-              content="Estimated supply of GNOTs to be airdropped. This number is not final, and is subject to change."
-            >
+            <Tooltip width={215} content="Total GNOTs to be airdropped to Cosmos and AtomOne holders.">
               <Button width="16px" height="16px" radius="50%" bgColor="surface">
                 <IconInfo className="svg-info" />
               </Button>
@@ -70,7 +67,7 @@ export const StandardNetworkSupplyCard = () => {
             <Text type="p4" color="tertiary">
               Airdrop&nbsp;Holders
             </Text>
-            <Tooltip content="Total number of holders eligible for the GNOT airdrop. This number is not final and is subject to change.">
+            <Tooltip content="Total number of holders receiving 1 GNOT or more.">
               <Button width="16px" height="16px" radius="50%" bgColor="surface">
                 <IconInfo className="svg-info" />
               </Button>

--- a/src/components/view/main-card/main-card.tsx
+++ b/src/components/view/main-card/main-card.tsx
@@ -30,10 +30,7 @@ const MainCard = ({ breakpoint, isCustomNetwork }: MainCardProps) => {
       <StyledCard>
         <Text type="h5" color="primary" className="title-info">
           GNOT&nbsp;Supply
-          <Tooltip
-            width={229}
-            content="This number represents the total supply at Genesis in testnets, which can be subject to change in mainnet."
-          >
+          <Tooltip width={229} content="Total GNOT supply at Genesis.">
             <Button width="16px" height="16px" radius="50%" bgColor="base">
               <IconInfo className="svg-info" />
             </Button>


### PR DESCRIPTION
## Summary
- Update the homepage GNOT Supply tooltip copy to reflect the Genesis total supply wording.
- Update the Airdrop Supply and Airdrop Holders tooltip copy in both standard and custom network cards.
- Keep the change scoped to tooltip text only without changing any data flow.

## Testing
- `npm run lint -- --file src/components/view/main-card/main-card.tsx --file src/components/view/main-card/cards/supply/StandardNetworkSupplyCard.tsx --file src/components/view/main-card/cards/supply/CustomNetworkSupplyCard.tsx`