### PR TITLE
feat: enhance transaction message components with file handling

### DIFF
--- a/src/components/view/transaction/transaction-contract-details/StandardNetworkTransactionContractsDetails.tsx
+++ b/src/components/view/transaction/transaction-contract-details/StandardNetworkTransactionContractsDetails.tsx
@@ -1,34 +1,67 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 
-import { Transaction, TransactionContractInfo } from "@/types/data-type";
-import { TransactionContractModel } from "@/repositories/api/transaction/response";
 import { MESSAGE_TYPES } from "@/common/values/message-types.constant";
+import { TransactionContractModel } from "@/repositories/api/transaction/response";
+import { Transaction, TransactionContractInfo } from "@/types/data-type";
 
-import * as S from "./TransactionContractDetails.styles";
-import Text from "@/components/ui/text";
 import ShowLog from "@/components/ui/show-log";
+import Text from "@/components/ui/text";
+import { StorageDeposit } from "@/models/storage-deposit-model";
 import {
-  StandardNetworkBankMsgSendMessage,
   StandardNetworkAddPackageMessage,
+  StandardNetworkBankMsgSendMessage,
   StandardNetworkMsgCallMessage,
   StandardNetworkMsgRunMessage,
 } from "../transaction-message-card";
-import { StorageDeposit } from "@/models/storage-deposit-model";
+import * as S from "./TransactionContractDetails.styles";
 
 export const StandardNetworkTransactionContractDetails: React.FC<{
   transactionItem: TransactionContractInfo | Transaction | null;
+  rawTransaction: Transaction | null;
   isDesktop: boolean;
   getUrlWithNetwork: (uri: string) => string;
-  showLog?: string;
   storageDepositInfo?: StorageDeposit | null;
-}> = ({ transactionItem, isDesktop, getUrlWithNetwork, showLog, storageDepositInfo }) => {
+}> = ({ transactionItem, isDesktop, getUrlWithNetwork, rawTransaction }) => {
   const messages: TransactionContractModel[] = React.useMemo(() => {
     if (!transactionItem?.messages) {
       return [];
     }
     return transactionItem?.messages;
   }, [transactionItem?.messages]);
+
+  const getMessageFiles = React.useCallback(
+    (index: number) => {
+      if (!rawTransaction?.messages || rawTransaction?.messages.length <= index) {
+        return null;
+      }
+
+      const message = rawTransaction?.messages?.[index];
+      if (!message) {
+        return null;
+      }
+
+      const packageFiles = message?.package?.files;
+      if (!packageFiles) {
+        return null;
+      }
+
+      return packageFiles.map((file: any) => {
+        return {
+          name: file?.name ?? "",
+          body: file?.body ?? "",
+        };
+      });
+    },
+    [rawTransaction?.messages],
+  );
+
+  const showLog = React.useMemo(() => {
+    if (!rawTransaction) {
+      return null;
+    }
+    return rawTransaction.rawContent;
+  }, [rawTransaction]);
 
   if (!transactionItem) {
     return <React.Fragment />;
@@ -62,6 +95,7 @@ export const StandardNetworkTransactionContractDetails: React.FC<{
             <StandardNetworkAddPackageMessage
               message={message}
               isDesktop={isDesktop}
+              files={getMessageFiles(i) || []}
               getUrlWithNetwork={getUrlWithNetwork}
             />
           )}
@@ -70,6 +104,7 @@ export const StandardNetworkTransactionContractDetails: React.FC<{
             <StandardNetworkMsgRunMessage
               message={message}
               isDesktop={isDesktop}
+              files={getMessageFiles(i) || []}
               getUrlWithNetwork={getUrlWithNetwork}
             />
           )}

--- a/src/components/view/transaction/transaction-contract-details/TransactionContractDetails.tsx
+++ b/src/components/view/transaction/transaction-contract-details/TransactionContractDetails.tsx
@@ -1,21 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React from "react";
 import Link from "next/link";
+import React from "react";
 
 import { useTokenMeta } from "@/common/hooks/common/use-token-meta";
-import { Amount, Transaction, TransactionContractInfo } from "@/types/data-type";
 import { formatDisplayPackagePath } from "@/common/utils/string-util";
+import { Amount, Transaction, TransactionContractInfo } from "@/types/data-type";
 
-import * as S from "./TransactionContractDetails.styles";
-import Text from "@/components/ui/text";
-import { DLWrap, FitContentA } from "@/components/ui/detail-page-common-styles";
-import Badge from "@/components/ui/badge";
-import Tooltip from "@/components/ui/tooltip";
 import IconTooltip from "@/assets/svgs/icon-tooltip.svg";
-import TransactionTransferContract from "../transaction-transfer-contract/TransactionTransferContract";
+import Badge from "@/components/ui/badge";
+import { DLWrap, FitContentA } from "@/components/ui/detail-page-common-styles";
 import ShowLog from "@/components/ui/show-log";
+import Text from "@/components/ui/text";
+import Tooltip from "@/components/ui/tooltip";
 import { TransactionAddPackageContract } from "../transaction-add-package-contract/TransactionAddPackageContract";
 import { TransactionCallerContract } from "../transaction-caller-contract/TransactionCallerContract";
+import { TransactionMsgRunContract } from "../transaction-msg-run-contract/TransactionMsgRunContract";
+import TransactionTransferContract from "../transaction-transfer-contract/TransactionTransferContract";
+import * as S from "./TransactionContractDetails.styles";
 
 const TOOLTIP_PACKAGE_PATH = (
   <>
@@ -78,6 +79,42 @@ export const TransactionContractDetails: React.FC<{
     }
   }, []);
 
+  const isVmAddPkg = React.useCallback((message: any) => {
+    return message?.["@type"] === "/vm.m_addpkg";
+  }, []);
+
+  const isVmCall = React.useCallback((message: any) => {
+    return message?.["@type"] === "/vm.m_call";
+  }, []);
+
+  const isBankMsgSend = React.useCallback((message: any) => {
+    return message?.["@type"] === "/bank.MsgSend";
+  }, []);
+
+  const isVmRun = React.useCallback((message: any) => {
+    return message?.["@type"] === "/vm.m_run";
+  }, []);
+
+  const getMessageFiles = React.useCallback((message: any) => {
+    console.log("message", message);
+    if (!isVmAddPkg(message) && !isVmRun(message)) {
+      return null;
+    }
+
+    const files = message?.files || message?.package?.files;
+
+    if (!files || !Array.isArray(files) || files.length === 0) {
+      return null;
+    }
+
+    return files.map(file => {
+      return {
+        name: file?.name ?? "",
+        body: file?.body ?? "",
+      };
+    });
+  }, []);
+
   if (!transactionItem) {
     return <React.Fragment />;
   }
@@ -89,7 +126,7 @@ export const TransactionContractDetails: React.FC<{
           {transactionItem.numOfMessage > 1 && (
             <Text type="h6" color="primary" margin="0px 0px 12px">{`#${i + 1}`}</Text>
           )}
-          {message["@type"] !== "/bank.MsgSend" && (
+          {isBankMsgSend(message) && (
             <>
               <DLWrap desktop={isDesktop}>
                 <dt>Name</dt>
@@ -154,7 +191,7 @@ export const TransactionContractDetails: React.FC<{
             </dd>
           </DLWrap>
 
-          {message["@type"] === "/vm.m_call" && message?.func === "Transfer" && (
+          {isVmCall(message) && message?.func === "Transfer" && (
             <TransactionTransferContract
               message={message}
               isDesktop={isDesktop}
@@ -162,7 +199,7 @@ export const TransactionContractDetails: React.FC<{
               getTokenAmount={getTokenAmount}
             />
           )}
-          {message["@type"] === "/bank.MsgSend" && (
+          {isBankMsgSend(message) && (
             <TransactionTransferContract
               message={message}
               isDesktop={isDesktop}
@@ -170,15 +207,24 @@ export const TransactionContractDetails: React.FC<{
               getTokenAmount={getTokenAmount}
             />
           )}
-          {message["@type"] === "/vm.m_addpkg" && (
+          {isVmAddPkg(message) && (
             <TransactionAddPackageContract
               message={message}
               isDesktop={isDesktop}
+              files={getMessageFiles(message) || []}
               getUrlWithNetwork={getUrlWithNetwork}
             />
           )}
           {hasCaller(message) && (
             <TransactionCallerContract message={message} isDesktop={isDesktop} getUrlWithNetwork={getUrlWithNetwork} />
+          )}
+          {isVmRun(message) && (
+            <TransactionMsgRunContract
+              message={message}
+              isDesktop={isDesktop}
+              files={getMessageFiles(message) || []}
+              getUrlWithNetwork={getUrlWithNetwork}
+            />
           )}
         </S.ContractListBox>
       ))}

--- a/src/components/view/transaction/transaction-info/standard-network-transaction-info/StandardNetworkTransactionInfo.tsx
+++ b/src/components/view/transaction/transaction-info/standard-network-transaction-info/StandardNetworkTransactionInfo.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 
-import { GnoEvent, TransactionContractInfo } from "@/types/data-type";
-import { useGetTransactionEventsByHeight } from "@/common/react-query/transaction/api/use-get-transaction-events-by-hash";
-import { useGetTransactionContractsByHeight } from "@/common/react-query/transaction/api";
-import { TransactionMapper } from "@/common/mapper/transaction/transaction-mapper";
 import { useTransaction } from "@/common/hooks/transactions/use-transaction";
+import { TransactionMapper } from "@/common/mapper/transaction/transaction-mapper";
+import { useGetTransactionContractsByHeight } from "@/common/react-query/transaction/api";
+import { useGetTransactionEventsByHeight } from "@/common/react-query/transaction/api/use-get-transaction-events-by-hash";
+import { GnoEvent, TransactionContractInfo } from "@/types/data-type";
 
+import { extractStorageDepositFromTxEvents } from "@/common/utils/transaction.utility";
+import TableSkeleton from "@/components/view/common/table-skeleton/TableSkeleton";
+import { EventDatatable } from "@/components/view/datatable/event";
 import DataListSection from "@/components/view/details-data-section/data-list-section";
 import { StandardNetworkTransactionContractDetails } from "../../transaction-contract-details/StandardNetworkTransactionContractsDetails";
-import { EventDatatable } from "@/components/view/datatable/event";
-import TableSkeleton from "@/components/view/common/table-skeleton/TableSkeleton";
-import { extractStorageDepositFromTxEvents } from "@/common/utils/transaction.utility";
 
 interface TransactionInfoProps {
   txHash: string;
@@ -77,10 +77,10 @@ const StandardNetworkTransactionInfo = ({
       {currentTab === "Messages" && (
         <StandardNetworkTransactionContractDetails
           transactionItem={txContracts}
+          rawTransaction={transactionItem}
           isDesktop={isDesktop}
           getUrlWithNetwork={getUrlWithNetwork}
           storageDepositInfo={storageDepositInfo}
-          showLog={transactionItem?.rawContent}
         />
       )}
       {currentTab === "Events" && <EventDatatable events={txEvents} isFetched={isFetchedEventsData} />}

--- a/src/components/view/transaction/transaction-message-card/transaction-add-package-message/StandardNetworkAddPackageMessage.tsx
+++ b/src/components/view/transaction/transaction-message-card/transaction-add-package-message/StandardNetworkAddPackageMessage.tsx
@@ -6,21 +6,23 @@ import { MESSAGE_TYPES } from "@/common/values/message-types.constant";
 import { TOOLTIP_PACKAGE_PATH } from "@/common/values/tooltip-content.constant";
 import { TransactionContractMessagesProps } from "@/models/api/transaction";
 
+import { GNOTToken } from "@/common/hooks/common/use-token-meta";
+import ShowLog from "@/components/ui/show-log";
 import {
+  AddressLink,
+  AmountBadge,
+  BadgeList,
+  BadgeText,
   Field,
   FieldWithTooltip,
-  BadgeText,
-  AddressLink,
   PkgPathLink,
-  BadgeList,
-  AmountBadge,
 } from "@/components/view/transaction/common";
 import { Amount } from "@/types";
-import { GNOTToken } from "@/common/hooks/common/use-token-meta";
 
 const StandardNetworkAddPackageMessage = ({
   isDesktop,
   message,
+  files = [],
   getUrlWithNetwork,
 }: TransactionContractMessagesProps) => {
   const send = React.useMemo(() => {
@@ -60,6 +62,7 @@ const StandardNetworkAddPackageMessage = ({
 
       <Field label="Files" isDesktop={isDesktop}>
         <BadgeList items={message?.files} />
+        {files && files?.length > 0 && <ShowLog isTabLog={true} files={files} btnTextType="Files" />}
       </Field>
 
       <Field label="Send" isDesktop={isDesktop}>

--- a/src/components/view/transaction/transaction-message-card/transaction-msg-run-message/StandardNetworkMsgRunMessage.tsx
+++ b/src/components/view/transaction/transaction-message-card/transaction-msg-run-message/StandardNetworkMsgRunMessage.tsx
@@ -3,14 +3,20 @@ import React from "react";
 
 import { toGNOTAmount } from "@/common/utils/native-token-utility";
 import { MESSAGE_TYPES } from "@/common/values/message-types.constant";
-import { AmountBadge, BadgeTooltipProps, StorageDepositAmountBadge } from "../../common/TransactionMessageFields";
 import { TransactionContractMessagesProps } from "@/models/api/transaction";
+import { AmountBadge, BadgeTooltipProps } from "../../common/TransactionMessageFields";
 
-import { Field, BadgeText, AddressLink, BadgeList, HoverBadgeList } from "@/components/view/transaction/common";
-import { Amount } from "@/types";
 import { GNOTToken } from "@/common/hooks/common/use-token-meta";
+import ShowLog from "@/components/ui/show-log";
+import { AddressLink, BadgeList, BadgeText, Field, HoverBadgeList } from "@/components/view/transaction/common";
+import { Amount } from "@/types";
 
-const StandardNetworkMsgRunMessage = ({ isDesktop, message, getUrlWithNetwork }: TransactionContractMessagesProps) => {
+const StandardNetworkMsgRunMessage = ({
+  isDesktop,
+  message,
+  files = [],
+  getUrlWithNetwork,
+}: TransactionContractMessagesProps) => {
   const calledFunctions: BadgeTooltipProps[] | null = React.useMemo(() => {
     if (!message?.calledFunctions) return null;
 
@@ -55,6 +61,7 @@ const StandardNetworkMsgRunMessage = ({ isDesktop, message, getUrlWithNetwork }:
 
       <Field label="Files" isDesktop={isDesktop}>
         <BadgeList items={message?.files} />
+        {files && files?.length > 0 && <ShowLog isTabLog={true} files={files} btnTextType="Files" />}
       </Field>
 
       <Field label="Called Functions" isDesktop={isDesktop}>

--- a/src/components/view/transaction/transaction-msg-run-contract/TransactionMsgRunContract.tsx
+++ b/src/components/view/transaction/transaction-msg-run-contract/TransactionMsgRunContract.tsx
@@ -1,29 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Link from "next/link";
 import React from "react";
 import { v1 } from "uuid";
 
 import { toGNOTAmount } from "@/common/utils/native-token-utility";
-import Badge from "@/components/ui/badge";
-import { DLWrap, FitContentA } from "@/components/ui/detail-page-common-styles";
+import { DLWrap } from "@/components/ui/detail-page-common-styles";
 import ShowLog from "@/components/ui/show-log";
-import Text from "@/components/ui/text";
-import Tooltip from "@/components/ui/tooltip";
 import { AmountBadge, BadgeList } from "../common";
 
-interface TransactionAddPackageContractProps {
+interface TransactionMsgRunContractProps {
   message: any;
   isDesktop: boolean;
   files?: { name: string; body: string }[] | null;
   getUrlWithNetwork: (uri: string) => string;
 }
 
-export const TransactionAddPackageContract = ({
-  message,
-  isDesktop,
-  files = [],
-  getUrlWithNetwork,
-}: TransactionAddPackageContractProps) => {
+export const TransactionMsgRunContract = ({ message, isDesktop, files = [] }: TransactionMsgRunContractProps) => {
   const send = React.useMemo(() => {
     if (!message?.send) return null;
     return toGNOTAmount(message.send.value, message.send.denom);
@@ -34,55 +25,33 @@ export const TransactionAddPackageContract = ({
     return toGNOTAmount(message.maxDeposit.value, message.maxDeposit.denom);
   }, [message?.maxDeposit]);
 
-  const creatorAddress = React.useMemo(() => {
-    return message?.creator || message?.caller || "";
-  }, [message?.creator]);
-
-  const creatorName = React.useMemo(() => {
-    return creatorAddress || "";
-  }, [creatorAddress]);
-
   const hasFiles = React.useMemo(() => {
     if (!files) return false;
     if (!Array.isArray(files)) return false;
     if (files.length === 0) return false;
+
     return true;
   }, [files]);
 
   return (
     <>
-      <DLWrap desktop={isDesktop} key={v1()}>
-        <dt>Creator</dt>
-        <dd>
-          <Badge>
-            <Link href={getUrlWithNetwork(`/account/${creatorAddress}`)} passHref>
-              <FitContentA>
-                <Text type="p4" color="blue" className={"ellipsis"}>
-                  {creatorAddress ? <Tooltip content={creatorAddress}>{creatorName}</Tooltip> : "-"}
-                </Text>
-              </FitContentA>
-            </Link>
-          </Badge>
-        </dd>
-      </DLWrap>
-
       {hasFiles && (
         <DLWrap desktop={isDesktop} key={v1()}>
-          <dt>Files</dt>
-          <dd>
-            <BadgeList items={files?.map(file => file.name) || []} />
-            {files && files?.length > 0 && <ShowLog isTabLog={true} files={files} btnTextType="Files" />}
-          </dd>
+          <DLWrap desktop={isDesktop} key={v1()}>
+            <dt>Files</dt>
+            <dd>
+              <BadgeList items={files?.map(file => file.name) || []} />
+              {files && files?.length > 0 && <ShowLog isTabLog={true} files={files} btnTextType="Files" />}
+            </dd>
+          </DLWrap>
         </DLWrap>
       )}
-
       <DLWrap desktop={isDesktop} key={v1()}>
         <dt>Send</dt>
         <dd>
           <AmountBadge amount={send} />
         </dd>
       </DLWrap>
-
       <DLWrap desktop={isDesktop} key={v1()}>
         <dt>Max Deposit</dt>
         <dd>

--- a/src/models/api/transaction/transaction-model.ts
+++ b/src/models/api/transaction/transaction-model.ts
@@ -1,4 +1,3 @@
-import { StorageDeposit } from "@/models/storage-deposit-model";
 import { TransactionContractModel } from "@/repositories/api/transaction/response";
 import { Amount } from "@/types/data-type";
 
@@ -32,5 +31,6 @@ export interface TransactionModel extends BaseTransactionModel {
 export interface TransactionContractMessagesProps {
   message: TransactionContractModel;
   isDesktop: boolean;
+  files?: { name: string; body: string }[] | null;
   getUrlWithNetwork: (uri: string) => string;
 }


### PR DESCRIPTION
## Summary
This PR enhances transaction message rendering to support file attachments. For messages that include files (e.g., `vm.m_addpkg` and `vm.m_run`), the UI now shows a dedicated **Files** section and enables viewing the file contents via the existing log viewer.

### Changes
- Added `files` support to transaction message props/models (`files?: { name; body }[] | null`)
- Extracted message files in `TransactionContractDetails` and passed them down to message components
- Updated message UI components to render:
  - **Files** as badge list
  - **ShowLog** for viewing the file bodies
  - Updated handling for both `vm.m_addpkg` and `vm.m_run`
- Adjusted `StandardNetworkTransactionContractsDetails` / transaction info flow to provide `rawTransaction` where needed and derive `showLog` from it
