### PR TITLE
fix: improve block height validation logic

### DIFF
--- a/src/common/hooks/blocks/use-block.ts
+++ b/src/common/hooks/blocks/use-block.ts
@@ -200,7 +200,7 @@ export const useBlock = (height: number) => {
 
     // If the current block height is less than the latest block height, the next block exists
     return height < latestBlockHeight;
-  }, [block, height, latestBlockHeight]);
+  }, [height, latestBlockHeight]);
 
   const blockSummaryInfo: BlockSummaryInfo = useMemo(() => {
     return {

--- a/src/common/hooks/blocks/use-block.ts
+++ b/src/common/hooks/blocks/use-block.ts
@@ -1,15 +1,14 @@
-import { useMemo } from "react";
 import { useGetBlockQuery, useGetBlockResultQuery, useGetLatestBlockHeightQuery } from "@/common/react-query/block";
+import { toBech32Address } from "@/common/utils/bech32.utility";
 import { getDateDiff, getLocalDateString } from "@/common/utils/date-util";
 import { makeDisplayNumber, makeDisplayNumberWithDefault } from "@/common/utils/string-util";
-import { decodeTransaction, makeTransactionMessageInfo } from "@/common/utils/transaction.utility";
-import BigNumber from "bignumber.js";
-import { GnoEvent, Transaction } from "@/types/data-type";
 import { parseTokenAmount } from "@/common/utils/token.utility";
-import { GNOTToken } from "../common/use-token-meta";
-import { toBech32Address } from "@/common/utils/bech32.utility";
+import { decodeTransaction, makeTransactionMessageInfo } from "@/common/utils/transaction.utility";
 import { getDefaultMessageByBlockTransaction } from "@/repositories/utility";
-import { BlockSummaryInfo } from "@/types/data-type";
+import { BlockSummaryInfo, GnoEvent, Transaction } from "@/types/data-type";
+import BigNumber from "bignumber.js";
+import { useMemo } from "react";
+import { GNOTToken } from "../common/use-token-meta";
 
 export const useBlock = (height: number) => {
   const { data: latestBlockHeight } = useGetLatestBlockHeightQuery();
@@ -180,15 +179,13 @@ export const useBlock = (height: number) => {
       return false;
     }
 
-    // If block data exists, verify the actual block height
-    if (block) {
-      const currentHeight = Number(block.block.header.height);
-      return currentHeight > 0;
+    if (latestBlockHeight === undefined || latestBlockHeight === null) {
+      return false;
     }
 
-    // If there is no block data, it is impossible to determine whether it is a previous block.
-    return false;
-  }, [block, height]);
+    // If block data exists, verify the actual block height
+    return latestBlockHeight >= height;
+  }, [latestBlockHeight, height]);
 
   const hasNextBlock = useMemo(() => {
     // If latestBlockHeight is missing, it is impossible to determine whether the next block is valid.
@@ -201,13 +198,8 @@ export const useBlock = (height: number) => {
       return latestBlockHeight > 0;
     }
 
-    // Cannot determine if no block exists
-    if (!block) {
-      return false;
-    }
-
     // If the current block height is less than the latest block height, the next block exists
-    return Number(block.block.header.height) < latestBlockHeight;
+    return height < latestBlockHeight;
   }, [block, height, latestBlockHeight]);
 
   const blockSummaryInfo: BlockSummaryInfo = useMemo(() => {

--- a/src/common/hooks/blocks/use-block.ts
+++ b/src/common/hooks/blocks/use-block.ts
@@ -173,6 +173,10 @@ export const useBlock = (height: number) => {
     return block == null || isErrorBlockData;
   }, [block, isFetched, isErrorBlockData]);
 
+  const isValidBlockHeight = (height: number): boolean => {
+    return Number.isSafeInteger(height) && height >= 0;
+  };
+
   const hasPreviousBlock = useMemo(() => {
     // When the height is 0 (Genesis block), there is no previous block.
     if (height === 0) {
@@ -183,6 +187,10 @@ export const useBlock = (height: number) => {
       return false;
     }
 
+    if (!isValidBlockHeight(height)) {
+      return false;
+    }
+
     // If block data exists, verify the actual block height
     return latestBlockHeight >= height;
   }, [latestBlockHeight, height]);
@@ -190,6 +198,10 @@ export const useBlock = (height: number) => {
   const hasNextBlock = useMemo(() => {
     // If latestBlockHeight is missing, it is impossible to determine whether the next block is valid.
     if (latestBlockHeight === undefined || latestBlockHeight === null) {
+      return false;
+    }
+
+    if (!isValidBlockHeight(height)) {
       return false;
     }
 


### PR DESCRIPTION
## Summary

Fixes incorrect enable/disable state for **Previous** and **Next** block navigation on the block detail page (`BlockLayout` / `TitleOption`).

Navigation availability is now derived from the **URL block height** and the **latest chain block height**, instead of waiting for the current block’s RPC payload or comparing against `block.block.header.height`.

## Problem

`hasPreviousBlock` and `hasNextBlock` in `useBlock` depended on loaded block data:

- **Previous**: Enabled only when block RPC data existed and `block.block.header.height > 0`. While data was loading or missing, the Previous control stayed disabled even for valid heights.
- **Next**: Required block data and compared `block.block.header.height` to `latestBlockHeight`. The Next control could stay disabled during loading or when the route height and fetched header were out of sync.

Because `BlockLayout` wires these flags to `TitleOption`’s `disabled` props, users could not move between blocks until the current block request finished—or navigation could behave inconsistently.

## Solution

- **`hasPreviousBlock`**: `false` for genesis (`height === 0`); otherwise `latestBlockHeight >= height` when latest height is available.
- **`hasNextBlock`**: `height < latestBlockHeight` (with the existing genesis special case for `height === 0`), without requiring block RPC data.

This aligns prev/next activation with chain bounds and the page route, independent of whether the current block query has resolved.

## Changes

| File | Change |
|------|--------|
| `src/common/hooks/blocks/use-block.ts` | Refactor `hasPreviousBlock` / `hasNextBlock` memo logic; drop `block` dependency for next-block check |
