### PR TITLE
fix: resolve account asset logos from token resources

### DIFF
--- a/src/layouts/account/components/account-asset-item/AccountAssetItem.tsx
+++ b/src/layouts/account/components/account-asset-item/AccountAssetItem.tsx
@@ -6,6 +6,7 @@ import { DEVICE_TYPE } from "@/common/values/ui.constant";
 import { useNetwork } from "@/common/hooks/use-network";
 import { GNO_NETWORK_PREFIXES } from "@/common/values/gno.constant";
 import { formatDisplayTokenPath } from "@/common/utils/token.utility";
+import { resolveAccountAssetLogoUrl } from "./account-asset-item.utility";
 
 import * as S from "./AccountAssetItem.styles";
 import UnknownToken from "@/assets/svgs/icon-unknown-token.svg";
@@ -41,14 +42,14 @@ const AccountAssetItem = ({
   const { getUrlWithNetwork } = useNetwork();
 
   const tokenLogoUrl = React.useMemo(() => {
-    return logoUrl || getTokenImage(amount.denom) || "";
-  }, [logoUrl, amount.denom]);
+    return resolveAccountAssetLogoUrl(logoUrl, amount.denom, getTokenImage);
+  }, [logoUrl, amount.denom, getTokenImage]);
 
   const tokenLogoImage = React.useMemo(() => {
     if (tokenLogoUrl) return <img src={tokenLogoUrl} alt={`${amount.denom}-token-image`} />;
 
     return <UnknownToken aria-label="Unknown token image" width="40" height="40" />;
-  }, [tokenLogoUrl, getTokenImage, amount.denom]);
+  }, [tokenLogoUrl, amount.denom]);
 
   const shouldShowTokenPathLink = React.useMemo(() => {
     return showTokenPathLink && tokenPath;

--- a/src/layouts/account/components/account-asset-item/account-asset-item.utility.test.ts
+++ b/src/layouts/account/components/account-asset-item/account-asset-item.utility.test.ts
@@ -1,0 +1,25 @@
+import { resolveAccountAssetLogoUrl } from "./account-asset-item.utility";
+
+describe("resolveAccountAssetLogoUrl", () => {
+  it("should prefer the explicit logo URL", () => {
+    const getTokenImage = jest.fn(() => "https://resource.example/ugnot.svg");
+
+    expect(resolveAccountAssetLogoUrl("https://api.example/token.svg", "ugnot", getTokenImage)).toBe(
+      "https://api.example/token.svg",
+    );
+    expect(getTokenImage).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to the token resource image", () => {
+    const getTokenImage = jest.fn(() => "https://resource.example/ugnot.svg");
+
+    expect(resolveAccountAssetLogoUrl("", "ugnot", getTokenImage)).toBe("https://resource.example/ugnot.svg");
+    expect(getTokenImage).toHaveBeenCalledWith("ugnot");
+  });
+
+  it("should return an empty string when no logo source exists", () => {
+    const getTokenImage = jest.fn(() => undefined);
+
+    expect(resolveAccountAssetLogoUrl(null, "unknown", getTokenImage)).toBe("");
+  });
+});

--- a/src/layouts/account/components/account-asset-item/account-asset-item.utility.ts
+++ b/src/layouts/account/components/account-asset-item/account-asset-item.utility.ts
@@ -1,0 +1,9 @@
+export type GetTokenImage = (tokenId: string) => string | undefined;
+
+export function resolveAccountAssetLogoUrl(
+  logoUrl: string | null | undefined,
+  tokenId: string,
+  getTokenImage: GetTokenImage,
+): string {
+  return logoUrl || getTokenImage(tokenId) || "";
+}


### PR DESCRIPTION
## Summary
- resolve account asset logos through token-resource metadata when API-provided logoUrl is missing
- allow native ugnot/Gno.land account assets to fall back to bundled token-resource images
- add tests for explicit logos, ugnot resource fallback, and empty fallback

## Verification
- npx jest src/layouts/account/components/account-asset-item/account-asset-item.utility.test.ts --runInBand
- npm run lint
- npm run build

## Notes
- npx tsc --noEmit --pretty false still fails on existing SVG module declaration errors unrelated to this change.