### PR TITLE
chore: remove Try in GnoStudio integration from realm pages

### DIFF
--- a/src/common/values/url.constant.ts
+++ b/src/common/values/url.constant.ts
@@ -1,17 +1,8 @@
-export const GNOSTUDIO_BASE_URL = "https://gno.studio" as const;
-
 // template variable is [GNOWEB_URL] and [PACKAGE_POST_PATH]
 export const GNOWEB_REALM_TEMPLATE = "[GNOWEB_URL][PACKAGE_POST_PATH]" as const;
 
 // template variable is [GNOWEB_URL] and [USER_ADDRESS]
 export const GNOWEB_USER_TEMPLATE = "[GNOWEB_URL][USER_ADDRESS]" as const;
-
-// template variable is [PACKAGE_PATH] and [NETWORK]
-export const GNOSTUDIO_REALM_TEMPLATE = `${GNOSTUDIO_BASE_URL}/connect/view/[PACKAGE_PATH]?network=[NETWORK]` as const;
-
-// template variable is [PACKAGE_PATH], [NETWORK] and [FUNCTION_NAME]
-export const GNOSTUDIO_REALM_FUNCTION_TEMPLATE =
-  `${GNOSTUDIO_BASE_URL}/connect/view/[PACKAGE_PATH]?network=[NETWORK]#[FUNCTION_NAME]` as const;
 
 export const EFFECTIVE_GNO_EMBRACE_PANIC_DOC_URL = "https://docs.gno.land/resources/effective-gno/#embrace-panic";
 

--- a/src/components/view/realm/realm-summary/CustomNetworkRealmSummary.tsx
+++ b/src/components/view/realm/realm-summary/CustomNetworkRealmSummary.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import Link from "next/link";
 
 import { formatDisplayPackagePath } from "@/common/utils/string-util";
-import { NonMobile } from "@/common/hooks/use-media";
 import { Amount, Transaction } from "@/types/data-type";
-import { makeTemplate } from "@/common/utils/template.utils";
-import { GNOSTUDIO_REALM_FUNCTION_TEMPLATE, GNOSTUDIO_REALM_TEMPLATE } from "@/common/values/url.constant";
 import { GNOTToken, useTokenMeta } from "@/common/hooks/common/use-token-meta";
 import { useRealm } from "@/common/hooks/realms/use-realm";
 import { useNetwork } from "@/common/hooks/use-network";
@@ -14,9 +11,8 @@ import { useGetRealmTransactionsQuery } from "@/common/react-query/realm";
 
 import IconTooltip from "@/assets/svgs/icon-tooltip.svg";
 import IconCopy from "@/assets/svgs/icon-copy.svg";
-import IconLink from "@/assets/svgs/icon-link.svg";
 import DataSection from "../../details-data-section";
-import { DLWrap, FitContentA, LinkWrapper } from "@/components/ui/detail-page-common-styles";
+import { DLWrap, FitContentA } from "@/components/ui/detail-page-common-styles";
 import Badge from "@/components/ui/badge";
 import Tooltip from "@/components/ui/tooltip";
 import Text from "@/components/ui/text";
@@ -48,37 +44,9 @@ const TOOLTIP_BALANCE = (
 const CustomNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => {
   const { summary, isFetched } = useRealm(path);
   const { data: realmTransactions, isFetched: isFetchedRealmTransactions } = useGetRealmTransactionsQuery(path);
-  const { currentNetwork, getUrlWithNetwork } = useNetwork();
+  const { getUrlWithNetwork } = useNetwork();
   const { getName } = useUsername();
   const { getTokenAmount } = useTokenMeta();
-
-  const moveGnoStudioViewRealm = React.useCallback(() => {
-    if (!currentNetwork) {
-      return;
-    }
-
-    const url = makeTemplate(GNOSTUDIO_REALM_TEMPLATE, {
-      PACKAGE_PATH: path,
-      NETWORK: currentNetwork?.chainId || "",
-    });
-    window.open(url, "_blank");
-  }, [path, currentNetwork]);
-
-  const moveGnoStudioViewRealmFunction = React.useCallback(
-    (functionName: string) => {
-      if (!currentNetwork) {
-        return;
-      }
-
-      const url = makeTemplate(GNOSTUDIO_REALM_FUNCTION_TEMPLATE, {
-        PACKAGE_PATH: path,
-        NETWORK: currentNetwork?.chainId || "",
-        FUNCTION_NAME: functionName,
-      });
-      window.open(url, "_blank");
-    },
-    [path, currentNetwork],
-  );
 
   const balanceStr = React.useMemo(() => {
     if (!summary?.balance) {
@@ -123,15 +91,6 @@ const CustomNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => {
               <IconCopy className="svg-icon" />
             </Tooltip>
           </Badge>
-
-          <NonMobile>
-            <LinkWrapper onClick={moveGnoStudioViewRealm}>
-              <Text type="p4" className="ellipsis">
-                Try in GnoStudio
-              </Text>
-              <IconLink className="icon-link" />
-            </LinkWrapper>
-          </NonMobile>
         </dd>
       </DLWrap>
       <DLWrap desktop={isDesktop}>
@@ -158,12 +117,10 @@ const CustomNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => {
         <dt>Public Functions</dt>
         <dd className="function-wrapper">
           {summary?.funcs?.map((v: string, index: number) => (
-            <Badge className="link" key={index} type="blue" onClick={() => moveGnoStudioViewRealmFunction(v)}>
-              <Tooltip className="tooltip" content="Click to try in GnoStudio">
-                <Text type="p4" color="white">
-                  {v}
-                </Text>
-              </Tooltip>
+            <Badge key={index} type="blue">
+              <Text type="p4" color="white">
+                {v}
+              </Text>
             </Badge>
           ))}
         </dd>

--- a/src/components/view/realm/realm-summary/StandardNetworkRealmSummary.tsx
+++ b/src/components/view/realm/realm-summary/StandardNetworkRealmSummary.tsx
@@ -9,11 +9,7 @@ import { useGetRealmByPath } from "@/common/react-query/realm/api";
 import { toGNOTAmount } from "@/common/utils/native-token-utility";
 import { formatDisplayPackagePath } from "@/common/utils/string-util";
 import { makeTemplate } from "@/common/utils/template.utils";
-import {
-  GNOSTUDIO_REALM_FUNCTION_TEMPLATE,
-  GNOSTUDIO_REALM_TEMPLATE,
-  GNOWEB_REALM_TEMPLATE,
-} from "@/common/values/url.constant";
+import { GNOWEB_REALM_TEMPLATE } from "@/common/values/url.constant";
 import { Amount, RealmSummary } from "@/types/data-type";
 
 import IconCopy from "@/assets/svgs/icon-copy.svg";
@@ -55,7 +51,7 @@ const TOOLTIP_BALANCE = (
 const TOOLTIP_STORAGE_DEPOSIT = <>Total amount of GNOT deposited for storage in real time.</>;
 
 const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => {
-  const { currentNetwork, gnoWebUrl, getUrlWithNetwork } = useNetwork();
+  const { gnoWebUrl, getUrlWithNetwork } = useNetwork();
 
   const { data: realmData, isFetched: isFetchedRealmData } = useGetRealmByPath(path);
   const { data: storageDepositData, isFetched: isFetchedStorageDepositData } = useGetRealmStorageDepositByPath(path);
@@ -111,34 +107,6 @@ const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => 
     window.open(url, "_blank");
   }, [path, gnoWebUrl]);
 
-  const moveGnoStudioViewRealm = React.useCallback(() => {
-    if (!currentNetwork) {
-      return;
-    }
-
-    const url = makeTemplate(GNOSTUDIO_REALM_TEMPLATE, {
-      PACKAGE_PATH: path,
-      NETWORK: currentNetwork?.chainId || "",
-    });
-    window.open(url, "_blank");
-  }, [path, currentNetwork]);
-
-  const moveGnoStudioViewRealmFunction = React.useCallback(
-    (functionName: string) => {
-      if (!currentNetwork) {
-        return;
-      }
-
-      const url = makeTemplate(GNOSTUDIO_REALM_FUNCTION_TEMPLATE, {
-        PACKAGE_PATH: path,
-        NETWORK: currentNetwork?.chainId || "",
-        FUNCTION_NAME: functionName,
-      });
-      window.open(url, "_blank");
-    },
-    [path, currentNetwork],
-  );
-
   const displayBlockPublished = React.useMemo(() => {
     return formatDisplayBlockHeight(realmSummary?.blockPublished);
   }, [realmSummary?.blockPublished]);
@@ -188,13 +156,6 @@ const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => 
                 <IconLink className="icon-link" />
               </LinkWrapper>
             )}
-
-            <LinkWrapper onClick={moveGnoStudioViewRealm}>
-              <Text type="p4" className="ellipsis">
-                Try in GnoStudio
-              </Text>
-              <IconLink className="icon-link" />
-            </LinkWrapper>
           </NonMobile>
         </dd>
       </DLWrap>
@@ -222,12 +183,10 @@ const StandardNetworkRealmSummary = ({ path, isDesktop }: RealmSummaryProps) => 
         <dt>Public Functions</dt>
         <dd className="function-wrapper">
           {realmSummary?.funcs?.map((v: string, index: number) => (
-            <Badge className="link" key={index} type="blue" onClick={() => moveGnoStudioViewRealmFunction(v)}>
-              <Tooltip className="tooltip" content="Click to try in GnoStudio">
-                <Text type="p4" color="white">
-                  {v}
-                </Text>
-              </Tooltip>
+            <Badge key={index} type="blue">
+              <Text type="p4" color="white">
+                {v}
+              </Text>
             </Badge>
           ))}
         </dd>


### PR DESCRIPTION
Closes #235.

Removes the GnoStudio integration from the realm summary pages:

- Drops the standalone **"Try in GnoStudio"** link (`LinkWrapper`) under the realm path.
- Makes the **Public Functions** badges display-only — removes the per-function `onClick` that opened GnoStudio and the "Click to try in GnoStudio" tooltip.
- Removes the now-unused `GNOSTUDIO_BASE_URL`, `GNOSTUDIO_REALM_TEMPLATE`, and `GNOSTUDIO_REALM_FUNCTION_TEMPLATE` constants, plus the now-unused imports they left behind (`makeTemplate`, `LinkWrapper`, `IconLink`, `NonMobile` in the custom-network variant).

Affected files:
- `src/components/view/realm/realm-summary/StandardNetworkRealmSummary.tsx`
- `src/components/view/realm/realm-summary/CustomNetworkRealmSummary.tsx`
- `src/common/values/url.constant.ts`

The "Go to Gnoweb" link is untouched.