### PR TITLE
refactor: simplify event data handling in StandardNetworkEventDatatable

### DIFF
--- a/src/components/view/datatable/event/StandardNetworkEventDatatable.tsx
+++ b/src/components/view/datatable/event/StandardNetworkEventDatatable.tsx
@@ -14,7 +14,6 @@ import Link from "next/link";
 import { useNetwork } from "@/common/hooks/use-network";
 import Tooltip from "@/components/ui/tooltip";
 import IconCopy from "@/assets/svgs/icon-copy.svg";
-import { EVENT_TABLE_PAGE_SIZE } from "@/common/values/ui.constant";
 import { Button } from "@/components/ui/button";
 import { useWindowSize } from "@/common/hooks/use-window-size";
 
@@ -37,16 +36,10 @@ export const StandardNetworkEventDatatable = ({ isFetched, events, hasNextPage, 
   const { breakpoint } = useWindowSize();
   const themeMode = useRecoilValue(themeState);
   const [activeEvents, setActiveEvents] = useState<string[]>([]);
-  const [page, setPage] = useState(0);
 
   const loaded = useMemo(() => {
     return isFetched;
   }, [isFetched]);
-
-  const filteredEvents = useMemo(() => {
-    const endIndex = (page + 1) * EVENT_TABLE_PAGE_SIZE;
-    return events.slice(0, endIndex);
-  }, [events, page]);
 
   const toggleEventDetails = (eventId: string) => {
     setActiveEvents(prev => (prev.includes(eventId) ? prev.filter(id => id !== eventId) : [...prev, eventId]));
@@ -156,7 +149,7 @@ export const StandardNetworkEventDatatable = ({ isFetched, events, hasNextPage, 
             themeMode: themeMode,
           };
         })}
-        datas={filteredEvents}
+        datas={events}
         renderDetails={renderDetails}
       />
 


### PR DESCRIPTION
## Summary

- Remove redundant client-side pagination logic (`page` state and `filteredEvents` memo) from `StandardNetworkEventDatatable`.
- Pass the full `events` array from parent components directly to the datatable instead of slicing it locally with `EVENT_TABLE_PAGE_SIZE`.
- Rely on existing server-side pagination via `hasNextPage` and `nextPage` props (e.g. `fetchNextPage` from React Query hooks) for the "View More Events" flow.

## Motivation

`StandardNetworkEventDatatable` was applying an extra client-side slice on top of data already paginated by parent hooks (`useMappedApiBlockEvents`, account/realm event hooks, etc.). The local `page` state was never updated, so the table could cap visible rows at `EVENT_TABLE_PAGE_SIZE` even after more events were fetched upstream. This change removes that duplicate layer and aligns the component with how block, account, and realm event tables already load data.

## Changes

| File | Change |
|------|--------|
| `src/components/view/datatable/event/StandardNetworkEventDatatable.tsx` | Removed `EVENT_TABLE_PAGE_SIZE` import, `page` state, `filteredEvents` memo; `datas` now uses `events` directly |
