### PR TITLE
feat(realm): apply realm list sorting server-side

### DIFF
--- a/src/common/types/realm/realm-sort-option.ts
+++ b/src/common/types/realm/realm-sort-option.ts
@@ -1,4 +1,4 @@
-export type RealmListSortField = "none" | "packageName" | "totalCalls" | "storageDeposit";
+export type RealmListSortField = "none" | "packageName" | "totalCalls" | "storageDeposit" | "totalGasUsed";
 export type RealmListSortOrder = "none" | "asc" | "desc";
 
 export interface RealmListSortOption {

--- a/src/common/utils/sort/realm-list-sort.ts
+++ b/src/common/utils/sort/realm-list-sort.ts
@@ -1,6 +1,33 @@
-import { RealmListSortOption } from "@/common/types/realm";
+import { RealmListSortField, RealmListSortOption } from "@/common/types/realm";
 import { Realm } from "@/types/data-type";
+import { GetRealmsRequestParameters } from "@/repositories/api/realm/request";
 import { AmountUtils } from "../amount.utility";
+
+type RealmListApiSort = NonNullable<GetRealmsRequestParameters["sort"]>;
+
+// Maps a sortable table column (header key) to the API `sort` value so sorting
+// runs server-side over the full realm set instead of the loaded page only.
+const FIELD_TO_API_SORT: Record<Exclude<RealmListSortField, "none">, RealmListApiSort> = {
+  packageName: "name",
+  totalCalls: "totalCallCount",
+  storageDeposit: "storageDeposit",
+  totalGasUsed: "totalGasUsed",
+};
+
+// Translates the UI sort option into API request params. Returns no sort/order
+// when unsorted so the server falls back to its default (newest first).
+export const toRealmListApiSortParams = (
+  sortOption: RealmListSortOption,
+): Pick<GetRealmsRequestParameters, "sort" | "order"> => {
+  if (sortOption.field === "none" || sortOption.order === "none") {
+    return {};
+  }
+
+  return {
+    sort: FIELD_TO_API_SORT[sortOption.field],
+    order: sortOption.order,
+  };
+};
 
 export const sortRealmList = (items: Realm[] = [], sortOption: RealmListSortOption) => {
   if (!items.length || sortOption.field === "none" || sortOption.order === "none") {

--- a/src/components/view/realms/realm-data/StandardNetworkRealmsData.tsx
+++ b/src/components/view/realms/realm-data/StandardNetworkRealmsData.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { DEVICE_TYPE } from "@/common/values/ui.constant";
-import { sortRealmList } from "@/common/utils/sort/realm-list-sort";
+import { toRealmListApiSortParams } from "@/common/utils/sort/realm-list-sort";
 import { RealmListSortOption } from "@/common/types/realm";
 
 import { StandardNetworkRealmListTable } from "../realm-list-table/standard-network-realm-list-table/StandardNetworkRealmListTable";
@@ -14,20 +14,18 @@ interface StandardNetworkRealmsDataProps {
 }
 
 const StandardNetworkRealmsData = ({ breakpoint, sortOption, setSortOption }: StandardNetworkRealmsDataProps) => {
-  const { data, isFetched, hasNextPage, fetchNextPage } = useMappedApiRealms();
+  // Sorting is applied server-side over the full realm set; the sort option is
+  // forwarded as API params so pagination follows the server order.
+  const apiParams = React.useMemo(() => toRealmListApiSortParams(sortOption), [sortOption.field, sortOption.order]);
 
-  const realmListData = React.useMemo(() => {
-    if (!data) return [];
-
-    return sortRealmList(data, sortOption);
-  }, [data, sortOption.field, sortOption.order]);
+  const { data, isFetched, hasNextPage, fetchNextPage } = useMappedApiRealms(apiParams);
 
   return (
     <StandardNetworkRealmListTable
       breakpoint={breakpoint}
       sortOption={sortOption}
       setSortOption={setSortOption}
-      realms={realmListData}
+      realms={data}
       isFetched={isFetched}
       hasNextPage={hasNextPage}
       fetchNextPage={fetchNextPage}

--- a/src/components/view/realms/realm-list-table/standard-network-realm-list-table/StandardNetworkRealmListTable.tsx
+++ b/src/components/view/realms/realm-list-table/standard-network-realm-list-table/StandardNetworkRealmListTable.tsx
@@ -110,6 +110,7 @@ export const StandardNetworkRealmListTable = ({
     return DatatableOption.Builder.builder<Realm>()
       .key("totalGasUsed")
       .name("Total Gas Used")
+      .sort()
       .width(163)
       .renderOption(gasUsed => {
         return <AmountText {...toGNOTAmount(gasUsed.value, gasUsed.denom)} maxSize="p4" minSize="body1" />;

--- a/src/repositories/api/realm/request/get-realms-request.ts
+++ b/src/repositories/api/realm/request/get-realms-request.ts
@@ -3,7 +3,7 @@ export interface GetRealmsRequestParameters {
 
   limit?: number; // @default 20
 
-  sort?: "name" | "totalCallCount";
+  sort?: "name" | "totalCallCount" | "storageDeposit" | "totalGasUsed";
 
   order?: "asc" | "desc";
 }


### PR DESCRIPTION
## Summary
Moves realm list sorting to the server. Previously only the already-loaded page (~40 rows) was sorted on the client, so clicking ascending/descending sorted just the loaded rows instead of the full realm set. Also adds sorting for the Total Gas Used column. (Standard network path only; Custom network is unchanged.)

## Problem
`StandardNetworkRealmsData` sorted the fetched pages with a client comparator (`sortRealmList`), so the sort scope was limited to loaded rows.

## Changes
- Add `toRealmListApiSortParams`, which maps the UI sort option to API request params (`packageName→name`, `totalCalls→totalCallCount`, `storageDeposit→storageDeposit`, `totalGasUsed→totalGasUsed`; sends no params when unsorted so the server applies its default).
- Remove the client-side `sortRealmList` call in `StandardNetworkRealmsData` and forward the sort option as `useMappedApiRealms` params. Because `params` is part of the react-query key, changing the sort triggers a fresh server-side refetch automatically.
- Make the Total Gas Used header sortable via `.sort()`.
- Type updates: add `totalGasUsed` to `RealmListSortField`, and `storageDeposit`/`totalGasUsed` to the request `sort` union.

## Files
- `src/common/utils/sort/realm-list-sort.ts` (mapping helper)
- `src/components/view/realms/realm-data/StandardNetworkRealmsData.tsx`
- `src/components/view/realms/realm-list-table/standard-network-realm-list-table/StandardNetworkRealmListTable.tsx`
- `src/common/types/realm/realm-sort-option.ts`
- `src/repositories/api/realm/request/get-realms-request.ts`

## Notes
- The API change must be deployed first for the new sort values to take effect.
- `sortRealmList` is kept because the Custom network path still uses it.
