### PR TITLE
feat: show total event count in detail tab badge

### DIFF
--- a/src/common/services/block/use-mapped-api-block-events.ts
+++ b/src/common/services/block/use-mapped-api-block-events.ts
@@ -50,8 +50,12 @@ export const useMappedApiBlockEvents = (params: GetBlockEventsRequest) => {
   const isLoading = isApiLoading || !isDataReady;
   const isFetched = isApiFetched && isDataReady;
 
+  // The API returns the total event count only on the first page.
+  const totalCount = apiData?.pages?.[0]?.page?.totalCount;
+
   return {
     data: events,
+    totalCount,
     isFetched,
     isLoading,
     isError: isApiError,

--- a/src/components/view/account/account-transactions/StandardNetworkAccountTransactions.tsx
+++ b/src/components/view/account/account-transactions/StandardNetworkAccountTransactions.tsx
@@ -73,6 +73,9 @@ const StandardNetworkAccountTransactions = ({ address, isDesktop }: AccountTrans
 
   const [currentTab, setCurrentTab] = React.useState("Transactions");
 
+  // The API returns the total event count only on the first page.
+  const eventTotalCount = eventData?.pages?.[0]?.page?.totalCount;
+
   const detailTabs = React.useMemo(() => {
     return [
       {
@@ -80,10 +83,10 @@ const StandardNetworkAccountTransactions = ({ address, isDesktop }: AccountTrans
       },
       {
         tabName: "Events",
-        size: accountEvents.length,
+        size: eventTotalCount ?? accountEvents.length,
       },
     ];
-  }, [accountEvents]);
+  }, [accountEvents, eventTotalCount]);
 
   if (!isFetchedTransactionData) {
     return <AccountAddressSkeleton isDesktop={isDesktop} />;

--- a/src/components/view/block/block-info/StandardNetworkBlockInfo.tsx
+++ b/src/components/view/block/block-info/StandardNetworkBlockInfo.tsx
@@ -2,12 +2,11 @@ import React from "react";
 
 import { useMappedApiBlockEvents } from "@/common/services/block/use-mapped-api-block-events";
 
-import DataListSection from "../../details-data-section/data-list-section";
-import { BlockDetailDatatable } from "../../datatable";
-import { EventDatatable } from "../../datatable/event";
-import TableSkeleton from "../../common/table-skeleton/TableSkeleton";
 import { useMappedApiBlockTransactions } from "@/common/services/block/use-mapped-api-block-transactions";
+import TableSkeleton from "../../common/table-skeleton/TableSkeleton";
+import { BlockDetailDatatable } from "../../datatable";
 import { StandardNetworkEventDatatable } from "../../datatable/event/StandardNetworkEventDatatable";
+import DataListSection from "../../details-data-section/data-list-section";
 
 interface BlockInfoProps {
   blockHeight: number;
@@ -27,6 +26,7 @@ const StandardNetworkBlockInfo = ({ blockHeight, currentTab, setCurrentTab }: Bl
 
   const {
     data: events,
+    totalCount: eventsTotalCount,
     isFetched: isFetchedEvents,
     hasNextPage: eventsHasNextpage,
     fetchNextPage: eventsFetchNextPage,
@@ -39,10 +39,10 @@ const StandardNetworkBlockInfo = ({ blockHeight, currentTab, setCurrentTab }: Bl
       },
       {
         tabName: "Events",
-        size: events.length,
+        size: eventsTotalCount ?? events.length,
       },
     ];
-  }, [events]);
+  }, [events, eventsTotalCount]);
 
   if (!isFetchedEvents || !isFetchedTransactions) return <TableSkeleton />;
 

--- a/src/components/view/realm/realm-info/StandardNetworkRealmInfo.tsx
+++ b/src/components/view/realm/realm-info/StandardNetworkRealmInfo.tsx
@@ -42,6 +42,9 @@ const StandardNetworkRealmInfo = ({ path, currentTab, setCurrentTab }: RealmInfo
     return RealmMapper.realmEventFromApiResponses(allItems);
   }, [eventData?.pages]);
 
+  // The API returns the total event count only on the first page.
+  const eventTotalCount = eventData?.pages?.[0]?.page?.totalCount;
+
   const detailTabs = React.useMemo(() => {
     return [
       {
@@ -49,10 +52,10 @@ const StandardNetworkRealmInfo = ({ path, currentTab, setCurrentTab }: RealmInfo
       },
       {
         tabName: "Events",
-        size: realmEvents.length,
+        size: eventTotalCount ?? realmEvents.length,
       },
     ];
-  }, [realmEvents]);
+  }, [realmEvents, eventTotalCount]);
 
   if (!isFetchedTransactionData) return <TableSkeleton />;
 

--- a/src/repositories/api/account/response/get-account-events-response.ts
+++ b/src/repositories/api/account/response/get-account-events-response.ts
@@ -24,5 +24,6 @@ export interface GetAccountEventsResponse {
   page: {
     cursor: string;
     hasNext: boolean;
+    totalCount?: number;
   };
 }

--- a/src/repositories/api/block/response/get-block-events-response.ts
+++ b/src/repositories/api/block/response/get-block-events-response.ts
@@ -6,5 +6,6 @@ export interface GetBlockEventsResponse {
   page: {
     cursor: string;
     hasNext: boolean;
+    totalCount?: number;
   };
 }

--- a/src/repositories/api/realm/response/get-realm-events-response.ts
+++ b/src/repositories/api/realm/response/get-realm-events-response.ts
@@ -3,5 +3,5 @@ import { RealmEventModel } from "@/models/api/realm/realm-model";
 export interface GetRealmEventsResponse {
   items: RealmEventModel[];
 
-  page: { hasNext: boolean; cursor: string };
+  page: { hasNext: boolean; cursor: string; totalCount?: number };
 }


### PR DESCRIPTION
## Summary
The "Events" tab badge on the Block, Realm, and Account detail pages showed `events.length` — the number of currently loaded (paginated) events — instead of the total. It now shows the API-provided total event count. (Standard network only.)
## Changes
- Add optional `totalCount` to the events response `page` type for block, realm, and account endpoints.
- `useMappedApiBlockEvents` now returns `totalCount`, read from the first page's `page.totalCount`.
- Block/Realm/Account detail components use `totalCount ?? events.length` for the tab badge `size`, so the total shows once the first page loads and gracefully falls back to the loaded count while pending.
## Files
- `src/repositories/api/{block,realm,account}/response/get-*-events-response.ts`
- `src/common/services/block/use-mapped-api-block-events.ts`
- `src/components/view/block/block-info/StandardNetworkBlockInfo.tsx`
- `src/components/view/realm/realm-info/StandardNetworkRealmInfo.tsx`
- `src/components/view/account/account-transactions/StandardNetworkAccountTransactions.tsx`
## Notes
- Depends on the API change that adds `page.totalCount`; until deployed, the badge falls back to the loaded-events count.
- Custom network paths are unchanged.