### PR TITLE
fix(events): drop event count badge on realm/account, add it for transactions

### DIFF
--- a/src/components/view/account/account-transactions/CustomNetworkAccountTransactions.tsx
+++ b/src/components/view/account/account-transactions/CustomNetworkAccountTransactions.tsx
@@ -42,10 +42,9 @@ const CustomNetworkAccountTransactions = ({ address, isDesktop }: AccountTransac
       },
       {
         tabName: "Events",
-        size: transactionEvents.length,
       },
     ];
-  }, [transactionEvents]);
+  }, []);
 
   if (isLoadingTransactions || !isFetchedAccountTransactions) {
     return <AccountAddressSkeleton isDesktop={isDesktop} />;

--- a/src/components/view/account/account-transactions/StandardNetworkAccountTransactions.tsx
+++ b/src/components/view/account/account-transactions/StandardNetworkAccountTransactions.tsx
@@ -73,9 +73,6 @@ const StandardNetworkAccountTransactions = ({ address, isDesktop }: AccountTrans
 
   const [currentTab, setCurrentTab] = React.useState("Transactions");
 
-  // The API returns the total event count only on the first page.
-  const eventTotalCount = eventData?.pages?.[0]?.page?.totalCount;
-
   const detailTabs = React.useMemo(() => {
     return [
       {
@@ -83,10 +80,9 @@ const StandardNetworkAccountTransactions = ({ address, isDesktop }: AccountTrans
       },
       {
         tabName: "Events",
-        size: eventTotalCount ?? accountEvents.length,
       },
     ];
-  }, [accountEvents, eventTotalCount]);
+  }, []);
 
   if (!isFetchedTransactionData) {
     return <AccountAddressSkeleton isDesktop={isDesktop} />;

--- a/src/components/view/realm/realm-info/CustomNetworkRealmInfo.tsx
+++ b/src/components/view/realm/realm-info/CustomNetworkRealmInfo.tsx
@@ -25,10 +25,9 @@ const CustomNetworkRealmInfo = ({ path, currentTab, setCurrentTab }: RealmInfoPr
       },
       {
         tabName: "Events",
-        size: transactionEvents.length,
       },
     ];
-  }, [transactionEvents]);
+  }, []);
 
   if (!isFetched) return <TableSkeleton />;
 

--- a/src/components/view/realm/realm-info/StandardNetworkRealmInfo.tsx
+++ b/src/components/view/realm/realm-info/StandardNetworkRealmInfo.tsx
@@ -42,9 +42,6 @@ const StandardNetworkRealmInfo = ({ path, currentTab, setCurrentTab }: RealmInfo
     return RealmMapper.realmEventFromApiResponses(allItems);
   }, [eventData?.pages]);
 
-  // The API returns the total event count only on the first page.
-  const eventTotalCount = eventData?.pages?.[0]?.page?.totalCount;
-
   const detailTabs = React.useMemo(() => {
     return [
       {
@@ -52,10 +49,9 @@ const StandardNetworkRealmInfo = ({ path, currentTab, setCurrentTab }: RealmInfo
       },
       {
         tabName: "Events",
-        size: eventTotalCount ?? realmEvents.length,
       },
     ];
-  }, [realmEvents, eventTotalCount]);
+  }, []);
 
   if (!isFetchedTransactionData) return <TableSkeleton />;
 

--- a/src/components/view/transaction/transaction-info/standard-network-transaction-info/StandardNetworkTransactionInfo.tsx
+++ b/src/components/view/transaction/transaction-info/standard-network-transaction-info/StandardNetworkTransactionInfo.tsx
@@ -58,6 +58,9 @@ const StandardNetworkTransactionInfo = ({
     return extractStorageDepositFromTxEvents(transactionEvents);
   }, [transactionEvents]);
 
+  // The API returns the total event count only on the first page.
+  const eventTotalCount = eventsData?.pages?.[0]?.page?.totalCount;
+
   const detailTabs = React.useMemo(() => {
     return [
       {
@@ -65,10 +68,10 @@ const StandardNetworkTransactionInfo = ({
       },
       {
         tabName: "Events",
-        size: txEvents.length || 0,
+        size: eventTotalCount ?? txEvents.length,
       },
     ];
-  }, [eventsData]);
+  }, [eventsData, eventTotalCount, txEvents.length]);
 
   if (!isFetchedContractsData || !isFetchedEventsData) return <TableSkeleton />;
 

--- a/src/repositories/api/account/response/get-account-events-response.ts
+++ b/src/repositories/api/account/response/get-account-events-response.ts
@@ -24,6 +24,5 @@ export interface GetAccountEventsResponse {
   page: {
     cursor: string;
     hasNext: boolean;
-    totalCount?: number;
   };
 }

--- a/src/repositories/api/realm/response/get-realm-events-response.ts
+++ b/src/repositories/api/realm/response/get-realm-events-response.ts
@@ -3,5 +3,5 @@ import { RealmEventModel } from "@/models/api/realm/realm-model";
 export interface GetRealmEventsResponse {
   items: RealmEventModel[];
 
-  page: { hasNext: boolean; cursor: string; totalCount?: number };
+  page: { hasNext: boolean; cursor: string };
 }

--- a/src/repositories/api/transaction/response/get-transaction-events-response.ts
+++ b/src/repositories/api/transaction/response/get-transaction-events-response.ts
@@ -3,5 +3,5 @@ import { EventModel } from "@/models/api/event/event-model";
 export interface GetTransactionEventsResponse {
   items: EventModel[];
 
-  page: { hasNext: boolean; cursor: string };
+  page: { hasNext: boolean; cursor: string; totalCount?: number };
 }


### PR DESCRIPTION
## Summary
Removes the event-count badge from the Realm and Account detail tabs (the backend no longer returns a total there — the count was too slow on large realms/accounts), and switches the Transaction detail Events badge to the API-provided total count.

## Changes
- **Realm / Account detail** (Standard and Custom network): removed the Events tab `size`, so the badge no longer renders.
- **Transaction detail** (Standard network): Events tab `size` now uses the first page's `page.totalCount` instead of the loaded-events length.
- Response types: added `totalCount` to the transaction events response; removed it from realm and account events responses.
- Block detail badge is unchanged (Standard uses the API total, Custom keeps the loaded count).

## Notes
- Depends on the API change scoping `totalCount` to block/transaction endpoints.